### PR TITLE
Human-readable apx-diff output (--format human)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ not existing).
 | Region actions (row-level action/link in Cards/List regions) | ✅ `ApexRegion.actions` (`ApexRegionAction` — identifier/label/kind/target/url; distinct from the Dynamic-Action `action`) | 🚧 `region-action.ts` — presence-only, confirmed live for Cards' `action-d` shape (NOT unique per region — same label repeats once per record); List's `action-e` shape confirmed structurally different (menu-based), not wrapped. Click-through effects confirmed a DEAD END on the only live app available (every tested action is a non-functional placeholder) | ❌ not wired into generator yet |
 | Login / authentication | N/A | 🚧 field ids confirmed; a real race-condition bug found+fixed, fix not independently re-verified | ✅ login-required pages get a real generated test that logs in via `login()` in a `beforeEach`, gated at runtime on `APX_LOGIN_TEST_USERNAME`/`APX_LOGIN_TEST_PASSWORD` (skips cleanly if unset) — assumes the app's default auth scheme; custom-scheme apps fail loudly and specifically from `login()` instead |
 | Coverage mapping (`apx-coverage`) | — | ✅ | — |
-| Regression detection (`apx-diff`) | — | ✅ (pure AST diff, no live app needed) | — |
+| Regression detection (`apx-diff`) | — | ✅ (pure AST diff, no live app needed; `--format human` for prose output alongside the default structured tree) | — |
 
 Full list of limitations in docs/limitations.md; a few of the stories
 behind specific rows:

--- a/docs/ecosystem-roadmap.md
+++ b/docs/ecosystem-roadmap.md
@@ -1881,16 +1881,21 @@ more careful split than the maintainer's own framing gives it.
 
 ### Genuinely close to buildable — low risk, real precedent, thin layer over what already exists
 
-- **Human-readable export diff, item 3.** `apx-diff` already computes
-  exactly the structured facts this asks for — per-page added/removed/
-  changed items, regions, buttons (old→new field values), and now
-  field-by-field diffs for `branch`/`validation`/`process`/`computation`/
-  `column`/`action`/`dynamicAction` (Seventh/Continuation rounds). Turning
-  that already-computed structure into a sentence ("Page 12: Added button
-  Save, Removed validation Salary Required, Changed LOV Department") is a
-  templating layer over existing output, not new analysis — zero new
-  ground-truth risk, no new Oracle API surface, nothing ADR-002 governs.
-  **Build now.**
+- **Human-readable export diff, item 3 — DONE.** Shipped as
+  `formatDiffHuman()`/`formatPageHuman()` in `packages/generator/src/diff.ts`
+  + a `--format human` flag on the `apx-diff` CLI (`diff-cli.ts`), alongside
+  the existing structured (default) output, which is byte-for-byte
+  unchanged. Pure templating over the already-computed `DiffReport` — one
+  prose sentence per added/removed/changed page (e.g. "Page 3: Employee
+  (EMPLOYEE): Changed title: ..., Added item P3_EMAIL, Changed item
+  P3_ENAME (label: ... -> ...), Changed button save (label: ... -> ...).
+  Affects: p00003-employee.page.ts, p00003-employee.spec.ts."), folding in
+  the already-computed field-level changes parenthetically rather than
+  dropping them — zero new ground-truth risk, no new Oracle API surface,
+  nothing ADR-002 governs, exactly as anticipated below. `--json <path>`
+  is unaffected by `--format` and still writes the full structured report
+  either way. See GitHub issue #1 and `docs/tutorial.md` 2.10 for the full
+  example and usage.
 - **Coverage visualization, item 5.** Same shape: `apx-coverage` already
   computes touched/untouched/untrackable per identifier. A heatmap or
   checklist view is a presentation layer over data that already exists —

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -666,6 +666,32 @@ what changed — and which generated test files to review — before
 regenerating tests. `--json <path>` gives the same report as structured
 data for scripting.
 
+**Human-readable mode**: `--format human` renders the same, already-computed
+`DiffReport` as prose instead of the indented `+`/`-`/`~` tree above — one
+sentence per added/removed/changed page, meant for a PR description or a
+Slack message rather than a terminal. Nothing new is computed; this is a
+templating layer over the exact same data the structured (default) output
+uses, so it never drifts from it.
+
+```bash
+node /path/to/apx-testkit/packages/generator/dist/diff-cli.js <old-export-dir> <new-export-dir> --format human
+```
+
+```
+Page 3: Employee (EMPLOYEE): Changed title: "Employee" -> "Employee Record", Added item P3_EMAIL, Changed item P3_ENAME (label: "Name" -> "Full Name"), Changed button save (label: "Save" -> "Save Changes"). Affects: p00003-employee.page.ts, p00003-employee.spec.ts.
+Page 7: Reports (REPORTS) -- added. Will generate: p00007-reports.page.ts, p00007-reports.spec.ts.
+
+Summary: 1 added, 0 removed, 0 changed, 0 unchanged
+```
+
+`--format structured` (the default, unchanged) and `--format human` are
+both driven off the same `computeDiff()` result — `--json <path>` still
+writes the full structured `DiffReport` regardless of which `--format` you
+picked for the console output, so scripting and prose reading aren't
+mutually exclusive. `formatDiffHuman()`/`formatPageHuman()` are also
+exported from `@apx/testgen/diff` for anything that wants prose output
+without shelling out to the CLI (e.g. a future CI comment bot).
+
 ---
 
 ### 2.11 Interactive Grid

--- a/packages/generator/src/diff-cli.ts
+++ b/packages/generator/src/diff-cli.ts
@@ -1,16 +1,20 @@
 #!/usr/bin/env node
 import { existsSync, writeFileSync } from 'node:fs';
-import { computeDiff, type ComponentDiff } from './diff.js';
+import { computeDiff, formatDiffHuman, type ComponentDiff } from './diff.js';
 
 const args = process.argv.slice(2);
 const oldExportDir = args[0];
 const newExportDir = args[1];
 const jsonIdx = args.indexOf('--json');
 const jsonOut = jsonIdx >= 0 ? args[jsonIdx + 1] : undefined;
+const formatIdx = args.indexOf('--format');
+const format = formatIdx >= 0 ? args[formatIdx + 1] : 'structured';
 
 if (!oldExportDir || !newExportDir) {
-  console.error('Usage: apx-diff <old-export-dir> <new-export-dir> [--json <report.json>]');
+  console.error('Usage: apx-diff <old-export-dir> <new-export-dir> [--json <report.json>] [--format structured|human]');
   console.error('  Pure AST-to-AST comparison -- no live app or browser needed.');
+  console.error('  --format structured (default): the indented +/-/~ tree.');
+  console.error('  --format human: prose sentences, one per changed/added/removed page.');
   process.exit(2);
 }
 if (!existsSync(oldExportDir)) {
@@ -21,54 +25,62 @@ if (!existsSync(newExportDir)) {
   console.error(`New export directory not found: ${newExportDir}`);
   process.exit(2);
 }
-
-const symbol: Record<ComponentDiff['kind'], string> = { added: '+', removed: '-', changed: '~' };
-
-function printComponentDiffs(label: string, diffs: ComponentDiff[]): void {
-  for (const d of diffs) {
-    console.log(`  ${symbol[d.kind]} ${label} ${d.identifier}`);
-    for (const change of d.changes) console.log(`      ${change}`);
-  }
+if (format !== 'structured' && format !== 'human') {
+  console.error(`Unknown --format value: ${format} (expected "structured" or "human")`);
+  process.exit(2);
 }
 
 const report = computeDiff(oldExportDir, newExportDir);
 
-console.log(`Regression report`);
-console.log(`  old: ${report.oldExportDir}`);
-console.log(`  new: ${report.newExportDir}`);
-console.log('');
+if (format === 'human') {
+  console.log(formatDiffHuman(report));
+} else {
+  const symbol: Record<ComponentDiff['kind'], string> = { added: '+', removed: '-', changed: '~' };
 
-for (const p of report.pages) {
-  if (p.kind === 'added') {
-    console.log(`+ page ${p.id}: ${p.name ?? p.alias} (${p.alias})`);
-    console.log(`    generated: ${p.affectedFiles.join(', ')}`);
-    console.log('');
-    continue;
-  }
-  if (p.kind === 'removed') {
-    console.log(`- page ${p.id}: ${p.name ?? p.alias} (${p.alias})`);
-    console.log(`    no longer generated: ${p.affectedFiles.join(', ')}`);
-    console.log('');
-    continue;
-  }
-  console.log(`~ page ${p.id}: ${p.name ?? p.alias} (${p.alias})`);
-  for (const change of p.pageChanges) console.log(`    ${change}`);
-  printComponentDiffs('item', p.items);
-  printComponentDiffs('region', p.regions);
-  printComponentDiffs('button', p.buttons);
-  printComponentDiffs('dynamicAction', p.dynamicActions);
-  printComponentDiffs('branch', p.branches);
-  printComponentDiffs('validation', p.validations);
-  printComponentDiffs('process', p.processes);
-  printComponentDiffs('computation', p.computations);
-  console.log(`    affected: ${p.affectedFiles.join(', ')}`);
+  const printComponentDiffs = (label: string, diffs: ComponentDiff[]): void => {
+    for (const d of diffs) {
+      console.log(`  ${symbol[d.kind]} ${label} ${d.identifier}`);
+      for (const change of d.changes) console.log(`      ${change}`);
+    }
+  };
+
+  console.log(`Regression report`);
+  console.log(`  old: ${report.oldExportDir}`);
+  console.log(`  new: ${report.newExportDir}`);
   console.log('');
-}
 
-const s = report.summary;
-console.log(
-  `Summary: ${s.pagesAdded} added, ${s.pagesRemoved} removed, ${s.pagesChanged} changed, ${s.pagesUnchanged} unchanged`,
-);
+  for (const p of report.pages) {
+    if (p.kind === 'added') {
+      console.log(`+ page ${p.id}: ${p.name ?? p.alias} (${p.alias})`);
+      console.log(`    generated: ${p.affectedFiles.join(', ')}`);
+      console.log('');
+      continue;
+    }
+    if (p.kind === 'removed') {
+      console.log(`- page ${p.id}: ${p.name ?? p.alias} (${p.alias})`);
+      console.log(`    no longer generated: ${p.affectedFiles.join(', ')}`);
+      console.log('');
+      continue;
+    }
+    console.log(`~ page ${p.id}: ${p.name ?? p.alias} (${p.alias})`);
+    for (const change of p.pageChanges) console.log(`    ${change}`);
+    printComponentDiffs('item', p.items);
+    printComponentDiffs('region', p.regions);
+    printComponentDiffs('button', p.buttons);
+    printComponentDiffs('dynamicAction', p.dynamicActions);
+    printComponentDiffs('branch', p.branches);
+    printComponentDiffs('validation', p.validations);
+    printComponentDiffs('process', p.processes);
+    printComponentDiffs('computation', p.computations);
+    console.log(`    affected: ${p.affectedFiles.join(', ')}`);
+    console.log('');
+  }
+
+  const s = report.summary;
+  console.log(
+    `Summary: ${s.pagesAdded} added, ${s.pagesRemoved} removed, ${s.pagesChanged} changed, ${s.pagesUnchanged} unchanged`,
+  );
+}
 
 if (jsonOut) {
   writeFileSync(jsonOut, JSON.stringify(report, null, 2));

--- a/packages/generator/src/diff.ts
+++ b/packages/generator/src/diff.ts
@@ -447,6 +447,104 @@ export function diffPageContents(a: ApexPage, b: ApexPage): PageContentsDiff {
   };
 }
 
+/**
+ * Human-readable/prose formatting over an already-computed `DiffReport` --
+ * a templating layer, not new analysis (see docs/ecosystem-roadmap.md
+ * "Ninth round", "Human-readable export diff"). Every fact rendered here
+ * already exists on `DiffReport`/`PageDiff`/`ComponentDiff`; this only
+ * turns it into sentences instead of the CLI's indented `+`/`-`/`~` tree.
+ * Kept alongside the existing structured output (`diff-cli.ts`'s default
+ * behavior), never replacing it -- other tooling/tests may depend on the
+ * structured shape staying exactly as it is.
+ */
+const CATEGORY_LABELS: ReadonlyArray<{ key: keyof PageContentsDiff; label: string }> = [
+  { key: 'items', label: 'item' },
+  { key: 'regions', label: 'region' },
+  { key: 'buttons', label: 'button' },
+  { key: 'dynamicActions', label: 'dynamic action' },
+  { key: 'branches', label: 'branch' },
+  { key: 'validations', label: 'validation' },
+  { key: 'processes', label: 'process' },
+  { key: 'computations', label: 'computation' },
+];
+
+const VERB_BY_KIND: Record<ChangeKind, 'Added' | 'Removed' | 'Changed'> = {
+  added: 'Added',
+  removed: 'Removed',
+  changed: 'Changed',
+};
+
+/**
+ * One clause for a single added/removed/changed item/region/button/etc,
+ * e.g. `Added button SAVE` or `Changed item P3_ENAME (label: "Name" ->
+ * "Full Name")`. For 'changed', the already-computed field-level changes
+ * are folded in parenthetically rather than dropped -- losing that detail
+ * would make prose mode strictly less informative than structured mode,
+ * which this project's "never lose information" discipline (see
+ * DESIGN_GUARDRAILS.md) argues against.
+ */
+export function describeComponentChange(categoryLabel: string, d: ComponentDiff): string {
+  const base = `${VERB_BY_KIND[d.kind]} ${categoryLabel} ${d.identifier}`;
+  if (d.kind === 'changed' && d.changes.length > 0) return `${base} (${d.changes.join('; ')})`;
+  return base;
+}
+
+/**
+ * One prose sentence (or two, for added/removed pages) per `PageDiff`.
+ * `report.pages` only ever contains added/removed/changed pages
+ * (`computeDiff` never pushes an unchanged one), so every entry here has
+ * something to say.
+ */
+export function formatPageHuman(p: PageDiff): string {
+  const header = `Page ${p.id}: ${p.name ?? p.alias} (${p.alias})`;
+
+  if (p.kind === 'added') {
+    return `${header} -- added. Will generate: ${p.affectedFiles.join(', ')}.`;
+  }
+  if (p.kind === 'removed') {
+    return `${header} -- removed. No longer generates: ${p.affectedFiles.join(', ')}.`;
+  }
+
+  const clauses: string[] = [];
+  for (const change of p.pageChanges) clauses.push(`Changed ${change}`);
+  for (const { key, label } of CATEGORY_LABELS) {
+    for (const d of p[key] as ComponentDiff[]) {
+      clauses.push(describeComponentChange(label, d));
+    }
+  }
+
+  const body = clauses.length > 0 ? clauses.join(', ') : 'changed (see raw diff)';
+  return `${header}: ${body}. Affects: ${p.affectedFiles.join(', ')}.`;
+}
+
+/**
+ * The full report as prose -- one line per changed/added/removed page plus
+ * the same summary line the structured CLI output ends with. This is the
+ * function `--format human` in `diff-cli.ts` calls; also usable directly
+ * by anything importing `@apx/testgen/diff` (e.g. `@apx/mcp`, a future CI
+ * comment bot) without going through the CLI at all.
+ */
+export function formatDiffHuman(report: DiffReport): string {
+  const lines: string[] = [];
+  lines.push('Regression report (human-readable)');
+  lines.push(`  old: ${report.oldExportDir}`);
+  lines.push(`  new: ${report.newExportDir}`);
+  lines.push('');
+
+  if (report.pages.length === 0) {
+    lines.push('No page changes detected.');
+  } else {
+    for (const p of report.pages) lines.push(formatPageHuman(p));
+  }
+
+  lines.push('');
+  const s = report.summary;
+  lines.push(
+    `Summary: ${s.pagesAdded} added, ${s.pagesRemoved} removed, ${s.pagesChanged} changed, ${s.pagesUnchanged} unchanged`,
+  );
+  return lines.join('\n');
+}
+
 export function computeDiff(oldExportDir: string, newExportDir: string): DiffReport {
   const oldResult = parseApp(loadExport(resolve(oldExportDir)));
   const newResult = parseApp(loadExport(resolve(newExportDir)));

--- a/packages/generator/test/diff-human.test.ts
+++ b/packages/generator/test/diff-human.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import type { ComponentDiff, DiffReport, PageDiff } from '../src/diff.js';
+import { describeComponentChange, formatDiffHuman, formatPageHuman } from '../src/diff.js';
+
+/**
+ * Regression tests for the human-readable/prose formatter over an
+ * already-computed `DiffReport` (see docs/ecosystem-roadmap.md "Ninth
+ * round", GitHub issue #1 "Human-readable apx-diff output"). This is pure
+ * templating over data `diff-field-coverage.test.ts` already proves
+ * `computeDiff`/`diffPageContents` compute correctly -- these tests only
+ * check the sentence shape, not the underlying diff logic, so synthetic
+ * `PageDiff`/`DiffReport` fixtures (no export directories, no filesystem)
+ * are constructed directly.
+ */
+
+const LOC_FREE_PAGE_BASE: Omit<PageDiff, 'kind' | 'pageChanges' | 'items' | 'regions' | 'buttons' | 'dynamicActions' | 'branches' | 'validations' | 'processes' | 'computations'> = {
+  id: 3,
+  alias: 'EMPLOYEE',
+  name: 'Employee',
+  affectedFiles: ['p00003-employee.page.ts', 'p00003-employee.spec.ts'],
+};
+
+function emptyPage(overrides: Partial<PageDiff>): PageDiff {
+  return {
+    ...LOC_FREE_PAGE_BASE,
+    kind: 'changed',
+    pageChanges: [],
+    items: [],
+    regions: [],
+    buttons: [],
+    dynamicActions: [],
+    branches: [],
+    validations: [],
+    processes: [],
+    computations: [],
+    ...overrides,
+  };
+}
+
+function componentDiff(overrides: Partial<ComponentDiff>): ComponentDiff {
+  return { kind: 'added', identifier: 'X', changes: [], ...overrides };
+}
+
+describe('describeComponentChange', () => {
+  it('renders an added component with no field detail', () => {
+    expect(describeComponentChange('button', componentDiff({ kind: 'added', identifier: 'SAVE' }))).toBe(
+      'Added button SAVE',
+    );
+  });
+
+  it('renders a removed component with no field detail', () => {
+    expect(describeComponentChange('validation', componentDiff({ kind: 'removed', identifier: 'val1' }))).toBe(
+      'Removed validation val1',
+    );
+  });
+
+  it('renders a changed component with field-level detail folded in parenthetically', () => {
+    const d = componentDiff({
+      kind: 'changed',
+      identifier: 'P3_ENAME',
+      changes: ['label: "Name" -> "Full Name"'],
+    });
+    expect(describeComponentChange('item', d)).toBe('Changed item P3_ENAME (label: "Name" -> "Full Name")');
+  });
+
+  it('joins multiple field changes with "; " inside the parenthetical', () => {
+    const d = componentDiff({
+      kind: 'changed',
+      identifier: 'BTN1',
+      changes: ['label: "Save" -> "Save Changes"', 'action: "SUBMIT" -> "SAVE"'],
+    });
+    expect(describeComponentChange('button', d)).toBe(
+      'Changed button BTN1 (label: "Save" -> "Save Changes"; action: "SUBMIT" -> "SAVE")',
+    );
+  });
+
+  it('renders a changed component with an empty changes array (e.g. a future category) with no parenthetical', () => {
+    const d = componentDiff({ kind: 'changed', identifier: 'br1', changes: [] });
+    expect(describeComponentChange('branch', d)).toBe('Changed branch br1');
+  });
+});
+
+describe('formatPageHuman', () => {
+  it('renders an added page as a single sentence naming the files it generates', () => {
+    const p = emptyPage({ kind: 'added', id: 7, alias: 'REPORTS', name: 'Reports', affectedFiles: ['p00007-reports.page.ts', 'p00007-reports.spec.ts'] });
+    expect(formatPageHuman(p)).toBe(
+      'Page 7: Reports (REPORTS) -- added. Will generate: p00007-reports.page.ts, p00007-reports.spec.ts.',
+    );
+  });
+
+  it('renders a removed page as a single sentence naming the files it no longer generates', () => {
+    const p = emptyPage({ kind: 'removed', id: 5, alias: 'LEGACY', name: 'Legacy Page', affectedFiles: ['p00005-legacy.page.ts', 'p00005-legacy.spec.ts'] });
+    expect(formatPageHuman(p)).toBe(
+      'Page 5: Legacy Page (LEGACY) -- removed. No longer generates: p00005-legacy.page.ts, p00005-legacy.spec.ts.',
+    );
+  });
+
+  it('falls back to the alias when name is null', () => {
+    const p = emptyPage({ kind: 'added', id: 9, alias: 'NO_NAME', name: null });
+    expect(formatPageHuman(p)).toContain('Page 9: NO_NAME (NO_NAME) -- added.');
+  });
+
+  it('renders page-level field changes as their own clause', () => {
+    const p = emptyPage({ pageChanges: ['title: "Employee" -> "Employee Record"'] });
+    expect(formatPageHuman(p)).toBe(
+      'Page 3: Employee (EMPLOYEE): Changed title: "Employee" -> "Employee Record". Affects: p00003-employee.page.ts, p00003-employee.spec.ts.',
+    );
+  });
+
+  it('combines page-level and every component-category change into one comma-joined sentence, in a stable order', () => {
+    const p = emptyPage({
+      pageChanges: ['title: "Employee" -> "Employee Record"'],
+      items: [
+        componentDiff({ kind: 'added', identifier: 'P3_EMAIL' }),
+        componentDiff({ kind: 'changed', identifier: 'P3_ENAME', changes: ['label: "Name" -> "Full Name"'] }),
+        componentDiff({ kind: 'removed', identifier: 'P3_JOB' }),
+      ],
+      buttons: [componentDiff({ kind: 'changed', identifier: 'save', changes: ['label: "Save" -> "Save Changes"'] })],
+      validations: [componentDiff({ kind: 'removed', identifier: 'Salary Required' })],
+    });
+    expect(formatPageHuman(p)).toBe(
+      'Page 3: Employee (EMPLOYEE): Changed title: "Employee" -> "Employee Record", ' +
+        'Added item P3_EMAIL, Changed item P3_ENAME (label: "Name" -> "Full Name"), Removed item P3_JOB, ' +
+        'Changed button save (label: "Save" -> "Save Changes"), ' +
+        'Removed validation Salary Required. ' +
+        'Affects: p00003-employee.page.ts, p00003-employee.spec.ts.',
+    );
+  });
+
+  it('exercises every component category label at least once (items/regions/buttons/dynamicActions/branches/validations/processes/computations)', () => {
+    const p = emptyPage({
+      items: [componentDiff({ kind: 'added', identifier: 'i1' })],
+      regions: [componentDiff({ kind: 'added', identifier: 'r1' })],
+      buttons: [componentDiff({ kind: 'added', identifier: 'b1' })],
+      dynamicActions: [componentDiff({ kind: 'added', identifier: 'da1' })],
+      branches: [componentDiff({ kind: 'added', identifier: 'br1' })],
+      validations: [componentDiff({ kind: 'added', identifier: 'v1' })],
+      processes: [componentDiff({ kind: 'added', identifier: 'p1' })],
+      computations: [componentDiff({ kind: 'added', identifier: 'c1' })],
+    });
+    const sentence = formatPageHuman(p);
+    expect(sentence).toContain('Added item i1');
+    expect(sentence).toContain('Added region r1');
+    expect(sentence).toContain('Added button b1');
+    expect(sentence).toContain('Added dynamic action da1');
+    expect(sentence).toContain('Added branch br1');
+    expect(sentence).toContain('Added validation v1');
+    expect(sentence).toContain('Added process p1');
+    expect(sentence).toContain('Added computation c1');
+  });
+});
+
+describe('formatDiffHuman', () => {
+  const baseReport: Omit<DiffReport, 'pages' | 'summary'> = {
+    oldExportDir: '/old/export',
+    newExportDir: '/new/export',
+  };
+
+  it('reports "no page changes" when the report has zero pages (identity diff)', () => {
+    const report: DiffReport = {
+      ...baseReport,
+      pages: [],
+      summary: { pagesAdded: 0, pagesRemoved: 0, pagesChanged: 0, pagesUnchanged: 4 },
+    };
+    const text = formatDiffHuman(report);
+    expect(text).toContain('old: /old/export');
+    expect(text).toContain('new: /new/export');
+    expect(text).toContain('No page changes detected.');
+    expect(text).toContain('Summary: 0 added, 0 removed, 0 changed, 4 unchanged');
+  });
+
+  it('renders one line per page and ends with the same summary line the structured CLI output uses', () => {
+    const added = emptyPage({ kind: 'added', id: 7, alias: 'REPORTS', name: 'Reports' });
+    const changed = emptyPage({ pageChanges: ['title: "Employee" -> "Employee Record"'] });
+    const report: DiffReport = {
+      ...baseReport,
+      pages: [changed, added],
+      summary: { pagesAdded: 1, pagesRemoved: 0, pagesChanged: 1, pagesUnchanged: 2 },
+    };
+    const text = formatDiffHuman(report);
+    const lines = text.split('\n');
+    expect(lines).toContain(formatPageHuman(changed));
+    expect(lines).toContain(formatPageHuman(added));
+    expect(lines[lines.length - 1]).toBe('Summary: 1 added, 0 removed, 1 changed, 2 unchanged');
+  });
+});


### PR DESCRIPTION
Fixes #1

## Summary
- Adds `formatDiffHuman()` / `formatPageHuman()` to `packages/generator/src/diff.ts` — a prose formatter built entirely on top of the already-computed `DiffReport`/`PageDiff`/`ComponentDiff` structures `computeDiff()` produces. No new analysis, no new Oracle API surface, nothing ADR-002 governs — pure templating, per the Ninth-round roadmap evaluation (`docs/ecosystem-roadmap.md`).
- Adds a `--format human` flag to the `apx-diff` CLI (`diff-cli.ts`), alongside the existing structured output, which is byte-for-byte unchanged (verified — see below). Default remains `--format structured`. `--json <path>` is unaffected by `--format` and still writes the full structured report either way.
- One sentence per added/removed/changed page, e.g.:
  ```
  Page 3: Employee (EMPLOYEE): Changed title: "Employee" -> "Employee Record", Added item P3_EMAIL, Changed item P3_ENAME (label: "Name" -> "Full Name"), Changed button save (label: "Save" -> "Save Changes"). Affects: p00003-employee.page.ts, p00003-employee.spec.ts.
  Page 7: Reports (REPORTS) -- added. Will generate: p00007-reports.page.ts, p00007-reports.spec.ts.

  Summary: 1 added, 0 removed, 0 changed, 0 unchanged
  ```
  Field-level changes are folded in parenthetically for `Changed` clauses rather than dropped, so prose mode stays at least as informative as structured mode.
- Docs updated together: `docs/tutorial.md` 2.10 (new "Human-readable mode" subsection with example), `README.md` capability matrix row, and `docs/ecosystem-roadmap.md`'s Ninth-round item marked DONE in place.
- New test file `packages/generator/test/diff-human.test.ts` (13 tests, synthetic `PageDiff`/`DiffReport` fixtures, no filesystem/export needed) covering: added/removed/changed component rendering, field-detail folding, multi-category ordering, page fallback naming, and the top-level `formatDiffHuman` summary/identity-diff cases.

## Regression sweep (per `.ai/knowledge/verification.md`)
- [x] `npm run build --workspaces` (parser/testkit/generator/mcp) — zero errors
- [x] `npm test` — full vitest suite, all green (generator 114/114 incl. new tests, parser 65/65 + 5 skipped integration, testkit 5/5)
- [x] `npm run lint` — zero errors
- [x] `cd spike && npx tsc --noEmit` — typechecks clean against the built `@apx/testkit`
- [x] Regenerated `packages/generator/test/fixtures/reference-fixtures`, diffed against committed `examples/employee-page` — byte-identical, twice (double-generate determinism gate)
- [x] Manually smoke-tested `--format human` against a real two-export diff (added page, changed title/items/button) and confirmed `--format structured` (default) output is unchanged, and an invalid `--format` value fails loudly (exit 2)

Note: this repo's real Oracle sample-app export corpus is intentionally local-only / never committed (per project convention), so "zero parser warnings across every real export" wasn't independently re-run in this sandbox — this change doesn't touch `@apx/parser` at all (pure `packages/generator` templating over the existing `DiffReport`), so there's no new parsing surface to warn about.

## Test plan
- [ ] `cd packages/generator && npx vitest run test/diff-human.test.ts`
- [ ] `node packages/generator/dist/diff-cli.js <old-export> <new-export> --format human` against a real before/after export pair
- [ ] Confirm `--format structured` (no flag) output is identical to pre-change behavior