### PR TITLE
Coverage visualization: heatmap/checklist HTML view for apx-coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,9 @@ waits (`callRegionMethodAndWaitForEvent`), a `--watch` CLI flag for editor
 auto-regeneration, and coverage mapping — set `APX_COVERAGE_LOG=<path>`
 before running your suite, then run `apx-coverage <export-dir>
 <touch-log-path>` to see which declared items/regions/buttons a run
-actually touched vs. missed. Still open: snapshot testing (needs a
+actually touched vs. missed (add `--html <report.html>` for a
+self-contained heatmap/checklist view of the same report, see
+docs/tutorial.md 2.9). Still open: snapshot testing (needs a
 masking-policy design), and Trees as content — the only Tree widget seen
 live so far is the universal left-nav reused for a login picker (see
 docs/ecosystem-roadmap.md), not a distinct page-content pattern.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -612,6 +612,43 @@ page 10: Mixed (MIXED)
   buttons: 0/0 (n/a)
 ```
 
+**Visual view (`--html`).** The terminal report above is text-only and easy
+to skim for one page, but tedious to scan across a large app. Add
+`--html <report.html>` (alongside, not instead of, the default text
+report) to get a self-contained HTML heatmap + checklist view of the
+exact same `CoverageReport` data — no new analysis, just a different
+rendering of what's already computed:
+
+```bash
+node /path/to/apx-testkit/packages/generator/dist/coverage-cli.js \
+  /path/to/your/export ./coverage.jsonl --html ./coverage-report.html
+```
+
+The output is one file, no external CSS/JS, safe to open directly from
+disk or attach as a CI artifact:
+
+- **Summary cards** at the top for overall items/regions/buttons
+  (touched/total + percentage), color-coded green (high coverage) through
+  red (low/zero) — gray for `n/a` (nothing declared).
+- **A per-page heatmap row** — one row per page, one colored cell per
+  category (items/regions/buttons), same color scale as the summary
+  cards, so you can spot which pages are weak at a glance without
+  expanding anything.
+- **A per-page checklist**, collapsed by default (click a page row to
+  expand): a ✓/✗ list of every untouched identifier per category (touched
+  identifiers are summarized as a single count — only untouched
+  identifiers are tracked by name in `CoverageReport`, so that's the only
+  granularity there is to show), plus untrackable regions listed
+  separately in their own line, same distinction as the text report.
+
+Same determinism guarantee as every other generated artifact in this
+project: the same `CoverageReport` always renders byte-identical HTML —
+safe to diff across runs. Both `renderCoverageHtml()` (a full standalone
+document) and `renderCoverageHtmlFragment()` (just the report content,
+for embedding into a host page's own DOM) are exported from
+`@apx/testgen/coverage-html` for programmatic use — e.g. a future CI
+dashboard that wants to embed this view directly instead of shelling out.
+
 ### 2.10 Regression detection
 
 **Status: VERIFIED**, and unlike everything else in this list, needs no

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -25,6 +25,7 @@
     ".": "./dist/cli.js",
     "./lib": "./dist/lib.js",
     "./coverage": "./dist/coverage.js",
+    "./coverage-html": "./dist/coverage-html.js",
     "./diff": "./dist/diff.js"
   }
 }

--- a/packages/generator/src/coverage-cli.ts
+++ b/packages/generator/src/coverage-cli.ts
@@ -1,18 +1,31 @@
 #!/usr/bin/env node
 import { existsSync, writeFileSync } from 'node:fs';
 import { computeCoverage, type CategoryCoverage, type RegionCoverage } from './coverage.js';
+import { renderCoverageHtml } from './coverage-html.js';
 
 const args = process.argv.slice(2);
 const exportDir = args[0];
 const touchLogPath = args[1];
 const jsonIdx = args.indexOf('--json');
 const jsonOut = jsonIdx >= 0 ? args[jsonIdx + 1] : undefined;
+const htmlIdx = args.indexOf('--html');
+const htmlOut = htmlIdx >= 0 ? args[htmlIdx + 1] : undefined;
 
 if (!exportDir || !touchLogPath) {
-  console.error('Usage: apx-coverage <export-dir> <touch-log-path> [--json <report.json>]');
+  console.error('Usage: apx-coverage <export-dir> <touch-log-path> [--json <report.json>] [--html <report.html>]');
   console.error('  <touch-log-path> is the file pointed to by APX_COVERAGE_LOG when the suite ran.');
   console.error('  Set APX_COVERAGE_LOG=<path> before running your Playwright suite to record touches;');
   console.error('  @apx/testkit only records when that env var is set (zero overhead otherwise).');
+  console.error('  --html writes a self-contained heatmap/checklist HTML view of the same report --');
+  console.error('  see docs/tutorial.md 2.9 for what it looks like.');
+  process.exit(2);
+}
+if (jsonIdx >= 0 && !jsonOut) {
+  console.error('--json requires an output path, e.g. --json report.json');
+  process.exit(2);
+}
+if (htmlIdx >= 0 && !htmlOut) {
+  console.error('--html requires an output path, e.g. --html report.html');
   process.exit(2);
 }
 if (!existsSync(exportDir)) {
@@ -70,4 +83,9 @@ console.log(line('buttons:', report.overall.buttons));
 if (jsonOut) {
   writeFileSync(jsonOut, JSON.stringify(report, null, 2));
   console.log(`\nFull JSON report written to ${jsonOut}`);
+}
+
+if (htmlOut) {
+  writeFileSync(htmlOut, renderCoverageHtml(report));
+  console.log(`\nHTML coverage report written to ${htmlOut}`);
 }

--- a/packages/generator/src/coverage-html.ts
+++ b/packages/generator/src/coverage-html.ts
@@ -1,0 +1,226 @@
+/**
+ * Presentation layer over `coverage.ts`'s already-computed `CoverageReport`
+ * -- a heatmap-plus-checklist HTML view. This module does NO new analysis;
+ * it only formats data `computeCoverage()` already produced. See
+ * docs/ecosystem-roadmap.md "Ninth round" for why this is scoped as a thin
+ * rendering layer, not a new coverage engine.
+ *
+ * Two entry points, deliberately split for reuse (a future scoped CI
+ * dashboard, tracked separately, is expected to embed this output rather
+ * than shell out and re-parse text):
+ *
+ * - `renderCoverageHtmlFragment()` -- the report content only, as a single
+ *   `<section class="apx-coverage-report">`, with all styling scoped under
+ *   that class. Safe to inline into a larger host page; the host supplies
+ *   (or reuses, via `COVERAGE_HTML_STYLE`) the `<style>` block.
+ * - `renderCoverageHtml()` -- wraps the fragment in a standalone
+ *   `<!doctype html>` document (own `<head>`/`<style>`) for direct
+ *   double-click-and-view use from the CLI's `--html` flag.
+ *
+ * Determinism: like every other generator artifact, the same
+ * `CoverageReport` must always produce byte-identical HTML -- no
+ * timestamps, no non-deterministic ordering. Ordering follows the same
+ * order `CoverageReport` itself already provides (pages sorted by id,
+ * untouched/untrackable lists in AST declaration order) -- this module
+ * never re-sorts or re-derives anything.
+ */
+import type { CategoryCoverage, CoverageReport, PageCoverage, RegionCoverage } from './coverage.js';
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Percentage touched, or `null` when `total === 0` (n/a -- not zero). */
+function percent(c: CategoryCoverage): number | null {
+  if (c.total === 0) return null;
+  return Math.round((c.touched / c.total) * 100);
+}
+
+/**
+ * Discrete heat bucket for a percentage. Discrete (not a continuous
+ * gradient) so the same percentage always maps to the same bucket/color
+ * regardless of floating-point rendering differences, and so the legend
+ * has a fixed, finite set of colors to document.
+ */
+function heatClass(pct: number | null): string {
+  if (pct === null) return 'apx-cov-na';
+  if (pct === 100) return 'apx-cov-100';
+  if (pct >= 80) return 'apx-cov-80';
+  if (pct >= 50) return 'apx-cov-50';
+  if (pct > 0) return 'apx-cov-low';
+  return 'apx-cov-0';
+}
+
+function pctLabel(pct: number | null): string {
+  return pct === null ? 'n/a' : `${pct}%`;
+}
+
+function heatCell(label: string, c: CategoryCoverage): string {
+  const pct = percent(c);
+  return (
+    `<td class="apx-cov-cell ${heatClass(pct)}" title="${escapeHtml(label)}: ${c.touched}/${c.total}">` +
+    `${c.touched}/${c.total}<br><span class="apx-cov-pct">${pctLabel(pct)}</span></td>`
+  );
+}
+
+function checklist(category: string, c: CategoryCoverage, touchedLabelPrefix = ''): string {
+  const touchedCount = c.touched;
+  const untouchedSet = new Set(c.untouched);
+  // The report only stores the untouched list, not the full declared list,
+  // so a synthetic "touched" placeholder count is shown as a single
+  // summary line rather than fabricating identifiers that were never
+  // recorded anywhere in CoverageReport.
+  const items: string[] = [];
+  if (touchedCount > 0) {
+    items.push(
+      `<li class="apx-cov-touched">&#10003; ${touchedCount} ${escapeHtml(touchedLabelPrefix)}touched (not itemized -- only untouched identifiers are tracked by name)</li>`,
+    );
+  }
+  for (const id of c.untouched) {
+    if (!untouchedSet.has(id)) continue;
+    items.push(`<li class="apx-cov-untouched">&#10007; ${escapeHtml(id)}</li>`);
+  }
+  if (items.length === 0) {
+    return `<p class="apx-cov-empty">no ${escapeHtml(category)} declared</p>`;
+  }
+  return `<ul class="apx-cov-checklist">${items.join('')}</ul>`;
+}
+
+function untrackableChecklist(regions: RegionCoverage): string {
+  if (regions.untrackable.length === 0) return '';
+  const items = regions.untrackable
+    .map(
+      (r) =>
+        `<li class="apx-cov-untrackable">&#8213; ${escapeHtml(r.identifier)} <span class="apx-cov-type">(${escapeHtml(r.type ?? 'unknown type')})</span></li>`,
+    )
+    .join('');
+  return (
+    `<p class="apx-cov-untrackable-label">untrackable (no @apx/testkit component for this type):</p>` +
+    `<ul class="apx-cov-checklist">${items}</ul>`
+  );
+}
+
+function renderPage(p: PageCoverage): string {
+  const title = `page ${p.id}: ${escapeHtml(p.name ?? p.alias ?? '')} (${escapeHtml(p.alias ?? '')})`;
+  return `
+<details class="apx-cov-page">
+  <summary>
+    ${title}
+    <table class="apx-cov-heatrow"><tr>
+      ${heatCell('items', p.items)}
+      ${heatCell('regions', p.regions)}
+      ${heatCell('buttons', p.buttons)}
+    </tr></table>
+  </summary>
+  <div class="apx-cov-detail">
+    <h4>Items</h4>
+    ${checklist('items', p.items)}
+    <h4>Regions</h4>
+    ${checklist('regions', p.regions)}
+    ${untrackableChecklist(p.regions)}
+    <h4>Buttons</h4>
+    ${checklist('buttons', p.buttons)}
+  </div>
+</details>`;
+}
+
+const STYLE = `
+.apx-coverage-report { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; color: #1a1a1a; background: #ffffff; padding: 1rem; color-scheme: light; }
+.apx-coverage-report h1 { font-size: 1.4rem; margin: 0 0 0.25rem; }
+.apx-coverage-report h4 { margin: 0.75rem 0 0.25rem; font-size: 0.9rem; }
+.apx-coverage-report .apx-cov-meta { color: #555; font-size: 0.85rem; margin: 0 0 1rem; }
+.apx-coverage-report .apx-cov-summary { display: flex; gap: 0.75rem; margin-bottom: 1.5rem; flex-wrap: wrap; }
+.apx-coverage-report .apx-cov-summary-card { border-radius: 6px; padding: 0.75rem 1rem; min-width: 8rem; }
+.apx-coverage-report .apx-cov-summary-card .apx-cov-label { display: block; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.03em; opacity: 0.8; }
+.apx-coverage-report .apx-cov-summary-card .apx-cov-value { display: block; font-size: 1.3rem; font-weight: 600; }
+.apx-coverage-report table.apx-cov-heatrow { display: inline-table; border-collapse: collapse; margin-left: 0.75rem; vertical-align: middle; }
+.apx-coverage-report td.apx-cov-cell { border-radius: 4px; padding: 0.2rem 0.5rem; font-size: 0.75rem; text-align: center; }
+.apx-coverage-report .apx-cov-pct { font-size: 0.65rem; opacity: 0.85; }
+.apx-coverage-report .apx-cov-page { border: 1px solid #ddd; border-radius: 6px; margin-bottom: 0.5rem; padding: 0.5rem 0.75rem; }
+.apx-coverage-report .apx-cov-page summary { cursor: pointer; font-weight: 600; display: flex; align-items: center; flex-wrap: wrap; gap: 0.25rem; }
+.apx-coverage-report .apx-cov-detail { margin-top: 0.5rem; }
+.apx-coverage-report ul.apx-cov-checklist { list-style: none; margin: 0.25rem 0; padding: 0; font-size: 0.85rem; }
+.apx-coverage-report ul.apx-cov-checklist li { padding: 0.1rem 0; }
+.apx-coverage-report .apx-cov-touched { color: #1a7f37; }
+.apx-coverage-report .apx-cov-untouched { color: #cf222e; }
+.apx-coverage-report .apx-cov-untrackable { color: #6e7781; }
+.apx-coverage-report .apx-cov-untrackable-label { font-size: 0.8rem; color: #6e7781; margin: 0.5rem 0 0; }
+.apx-coverage-report .apx-cov-type { font-style: italic; }
+.apx-coverage-report .apx-cov-empty { color: #6e7781; font-size: 0.85rem; font-style: italic; margin: 0.25rem 0; }
+.apx-coverage-report .apx-cov-100, .apx-coverage-report .apx-cov-80 { background: #d4f4dd; color: #0f5c26; }
+.apx-coverage-report .apx-cov-50 { background: #fff3c4; color: #6b5200; }
+.apx-coverage-report .apx-cov-low { background: #ffddb0; color: #7a3e00; }
+.apx-coverage-report .apx-cov-0 { background: #ffd6d6; color: #7a0000; }
+.apx-coverage-report .apx-cov-na { background: #e8e8e8; color: #555; }
+`.trim();
+
+function summaryCard(label: string, c: CategoryCoverage): string {
+  const pct = percent(c);
+  return (
+    `<div class="apx-cov-summary-card ${heatClass(pct)}">` +
+    `<span class="apx-cov-label">${escapeHtml(label)}</span>` +
+    `<span class="apx-cov-value">${c.touched}/${c.total} (${pctLabel(pct)})</span>` +
+    `</div>`
+  );
+}
+
+/**
+ * Renders the report content only -- a single `<section
+ * class="apx-coverage-report">`, with all rules scoped under that class so
+ * it is safe to inline into a host page's own DOM (the intended use for a
+ * future CI dashboard). The host page must supply its own `<style>` (see
+ * `COVERAGE_HTML_STYLE`, exported below, to reuse this module's exact
+ * styling) -- this function does not emit a `<style>` tag itself.
+ */
+export function renderCoverageHtmlFragment(report: CoverageReport): string {
+  const overallUntrackable = report.overall.regions.untrackable.length;
+  return `<section class="apx-coverage-report">
+  <h1>APX Coverage Report</h1>
+  <p class="apx-cov-meta">export: ${escapeHtml(report.exportDir)}<br>
+  touch log: ${escapeHtml(report.touchLogPath)} (${report.touchCount} touches recorded)${
+    overallUntrackable > 0 ? `<br>${overallUntrackable} untrackable region(s) across all pages (excluded from percentages -- see below)` : ''
+  }</p>
+
+  <div class="apx-cov-summary">
+    ${summaryCard('Items', report.overall.items)}
+    ${summaryCard('Regions', report.overall.regions)}
+    ${summaryCard('Buttons', report.overall.buttons)}
+  </div>
+
+  ${report.pages.map(renderPage).join('\n')}
+</section>`;
+}
+
+/**
+ * The exact `<style>` contents `renderCoverageHtml()` embeds -- exported
+ * so a host page/CI dashboard that only wants `renderCoverageHtmlFragment`
+ * can reuse the same look without duplicating it.
+ */
+export const COVERAGE_HTML_STYLE = STYLE;
+
+/**
+ * Renders a complete, standalone HTML document -- own `<head>`/`<style>`,
+ * no external stylesheets, fonts, or scripts. Safe to open directly from
+ * disk (`file://`) or attach as a CI artifact.
+ */
+export function renderCoverageHtml(report: CoverageReport): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>APX Coverage Report</title>
+<style>
+${COVERAGE_HTML_STYLE}
+</style>
+</head>
+<body style="margin: 0; background: #ffffff;">
+${renderCoverageHtmlFragment(report)}
+</body>
+</html>
+`;
+}

--- a/packages/generator/test/coverage-html.test.ts
+++ b/packages/generator/test/coverage-html.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import type { CoverageReport, PageCoverage } from '../src/coverage.js';
+import { COVERAGE_HTML_STYLE, renderCoverageHtml, renderCoverageHtmlFragment } from '../src/coverage-html.js';
+
+/**
+ * Pure, hand-built CoverageReport fixtures -- this module does no new
+ * analysis over `coverage.ts`'s output, so these tests exercise the
+ * rendering layer directly against representative shapes of that already-
+ * computed data, the same way coverage.test.ts drives `summarizeRegions`
+ * directly rather than round-tripping through a real .apx export.
+ */
+
+function page(overrides: Partial<PageCoverage>): PageCoverage {
+  return {
+    id: 1,
+    alias: 'page-one',
+    name: 'Page One',
+    items: { total: 2, touched: 1, untouched: ['P1_B'] },
+    regions: { total: 1, touched: 1, untouched: [], untrackable: [] },
+    buttons: { total: 1, touched: 0, untouched: ['save'] },
+    ...overrides,
+  };
+}
+
+function report(overrides: Partial<CoverageReport> = {}): CoverageReport {
+  const pages = overrides.pages ?? [page({})];
+  const overall = overrides.overall ?? {
+    items: { total: 2, touched: 1, untouched: ['P1_B'] },
+    regions: { total: 1, touched: 1, untouched: [], untrackable: [] },
+    buttons: { total: 1, touched: 0, untouched: ['save'] },
+  };
+  return {
+    exportDir: '/tmp/my-export',
+    touchLogPath: '/tmp/coverage.jsonl',
+    touchCount: 3,
+    ...overrides,
+    pages,
+    overall,
+  };
+}
+
+describe('renderCoverageHtml / renderCoverageHtmlFragment', () => {
+  it('is deterministic -- same report renders byte-identical HTML every call', () => {
+    const r = report();
+    expect(renderCoverageHtml(r)).toBe(renderCoverageHtml(r));
+    expect(renderCoverageHtmlFragment(r)).toBe(renderCoverageHtmlFragment(r));
+  });
+
+  it('renderCoverageHtml wraps a full standalone document; the fragment does not', () => {
+    const r = report();
+    const full = renderCoverageHtml(r);
+    const fragment = renderCoverageHtmlFragment(r);
+
+    expect(full).toContain('<!doctype html>');
+    expect(full).toContain('<style>');
+    expect(full).toContain(fragment);
+
+    expect(fragment).not.toContain('<!doctype html>');
+    expect(fragment).not.toContain('<html');
+    expect(fragment).not.toContain('<style>');
+    expect(fragment.startsWith('<section class="apx-coverage-report">')).toBe(true);
+  });
+
+  it('the exported style matches exactly what renderCoverageHtml embeds -- no drift for fragment consumers', () => {
+    const r = report();
+    const full = renderCoverageHtml(r);
+    expect(full).toContain(`<style>\n${COVERAGE_HTML_STYLE}\n</style>`);
+  });
+
+  it('includes export dir, touch log path, and touch count from the report', () => {
+    const html = renderCoverageHtmlFragment(report());
+    expect(html).toContain('/tmp/my-export');
+    expect(html).toContain('/tmp/coverage.jsonl');
+    expect(html).toContain('3 touches recorded');
+  });
+
+  it('renders per-page touched/total and percentage for each category', () => {
+    const html = renderCoverageHtmlFragment(
+      report({
+        pages: [
+          page({
+            id: 7,
+            alias: 'reports',
+            name: 'Reports',
+            items: { total: 4, touched: 2, untouched: ['P7_A', 'P7_B'] },
+          }),
+        ],
+      }),
+    );
+    expect(html).toContain('page 7: Reports (reports)');
+    expect(html).toContain('2/4');
+    expect(html).toContain('50%');
+  });
+
+  it('lists untouched identifiers by name, and summarizes touched as a count (no fabricated identifiers)', () => {
+    const html = renderCoverageHtmlFragment(
+      report({
+        pages: [page({ items: { total: 3, touched: 2, untouched: ['P1_C'] } })],
+      }),
+    );
+    expect(html).toContain('&#10007; P1_C');
+    expect(html).toContain('2 touched');
+  });
+
+  it('renders untrackable regions in their own checklist, distinct from untouched', () => {
+    const html = renderCoverageHtmlFragment(
+      report({
+        pages: [
+          page({
+            regions: {
+              total: 1,
+              touched: 1,
+              untouched: [],
+              untrackable: [{ identifier: 'nav-tree', type: 'tree' }],
+            },
+          }),
+        ],
+      }),
+    );
+    expect(html).toContain('untrackable (no @apx/testkit component for this type)');
+    expect(html).toContain('nav-tree');
+    expect(html).toContain('(tree)');
+  });
+
+  it('handles a category with zero declared items (n/a, not a crash or a bogus 0%)', () => {
+    const html = renderCoverageHtmlFragment(
+      report({
+        pages: [page({ buttons: { total: 0, touched: 0, untouched: [] } })],
+      }),
+    );
+    expect(html).toContain('n/a');
+    expect(html).toContain('no buttons declared');
+  });
+
+  it('escapes HTML-significant characters in identifiers and page names', () => {
+    const html = renderCoverageHtmlFragment(
+      report({
+        pages: [
+          page({
+            name: 'A & B <Page>',
+            items: { total: 1, touched: 0, untouched: ['P1_<X>&"Y"'] },
+          }),
+        ],
+      }),
+    );
+    expect(html).toContain('A &amp; B &lt;Page&gt;');
+    expect(html).toContain('P1_&lt;X&gt;&amp;&quot;Y&quot;');
+    // The raw, unescaped identifier must never appear verbatim.
+    expect(html).not.toContain('P1_<X>&"Y"');
+  });
+
+  it('color-codes 100% coverage differently from 0% coverage (heat classes present and distinct)', () => {
+    const fullyTouched = renderCoverageHtmlFragment(
+      report({
+        pages: [page({ buttons: { total: 1, touched: 1, untouched: [] } })],
+      }),
+    );
+    const untouched = renderCoverageHtmlFragment(
+      report({
+        pages: [page({ buttons: { total: 1, touched: 0, untouched: ['save'] } })],
+      }),
+    );
+    expect(fullyTouched).toContain('apx-cov-100');
+    expect(untouched).toContain('apx-cov-0');
+  });
+});


### PR DESCRIPTION
Fixes #2

## Summary

Adds a presentation layer over `apx-coverage`'s already-computed `CoverageReport` (`packages/generator/src/coverage.ts`) -- no new analysis, per the issue's scope and `docs/ecosystem-roadmap.md`'s "Ninth round" evaluation ("a heatmap or checklist view is a presentation layer over data that already exists ... Build now").

- New `packages/generator/src/coverage-html.ts`:
  - `renderCoverageHtml(report)` -- a complete, standalone `<!doctype html>` document (inline `<style>`, no external CSS/JS/fonts).
  - `renderCoverageHtmlFragment(report)` -- just the report content as a single `<section class="apx-coverage-report">`, for embedding into a host page. Exported separately (along with the exact `COVERAGE_HTML_STYLE` string `renderCoverageHtml` uses), since the held-back "scoped CI dashboard" issue (#3) is expected to embed this output directly rather than shell out and re-parse text.
  - Deterministic: same `CoverageReport` in -> byte-identical HTML out, same guarantee as every other generator artifact.
- `apx-coverage` gets an additive `--html <report.html>` flag, alongside (not replacing) the existing default text report and `--json`.
- Also tightened `--json`/`--html` argument validation (missing output path after the flag now errors clearly instead of silently writing `undefined`).

## Visualization format

One self-contained HTML file:
- **Summary cards** -- overall items/regions/buttons touched/total + percentage, color-coded (green = high coverage, yellow/orange = partial, red = 0%, gray = n/a/nothing declared).
- **Per-page heatmap row** -- one row per page, one colored cell per category, same color scale, so weak pages are visible at a glance without expanding anything.
- **Per-page checklist**, collapsed by default via native `<details>`/`<summary>` (no JS): touched count as a single summary line (only untouched identifiers are tracked by name in `CoverageReport`, so that's the only granularity there is to show honestly), a ✗ line per untouched identifier, and untrackable regions (tree/calendar/map -- no `@apx/testkit` component) listed in their own line, same distinction the text report already makes.

Verified live in a browser against both the committed synthetic fixture and a real 293-region Oracle sample export (`sample-charts`, 50 pages) -- summary cards render correctly (yellow/green/red), the per-page heatmap row matches the underlying numbers, and clicking a page row expands the checklist correctly. Initial version had a real dark-mode bug (dark text with no explicit background, invisible against a dark browser default) -- fixed by giving `.apx-coverage-report` its own explicit white background + `color-scheme: light`, confirmed with a screenshot before/after.

## Test plan

- [x] `packages/generator/test/coverage-html.test.ts` -- 10 new regression tests: determinism (byte-identical on repeat calls), fragment-vs-full-document shape, style embedding matches the exported `COVERAGE_HTML_STYLE` exactly, per-page percentages, untouched-identifier listing vs. touched-count summarization, untrackable-region checklist, zero-declared (`n/a`) handling, HTML escaping of special characters, heat-class color-coding.
- [x] Full regression sweep (`.ai/knowledge/verification.md`):
  - `npm run build --workspaces` (in dependency order: parser -> testkit -> generator -> mcp, per the README's own fresh-clone instructions) -- zero errors.
  - `npm test --if-present` -- full vitest suite, all passing (111 tests in `@apx/testgen`, 65 in `@apx/parser`, 5 in `@apx/testkit`).
  - `npm run lint` -- clean.
  - `cd spike && npx tsc --noEmit` -- clean.
  - Regenerated `packages/generator/test/fixtures/reference-fixtures` output and diffed against committed `examples/employee-page` -- byte-identical.
  - Parsed a real, local, non-committed 293-region Oracle sample export (`sample-charts`) through `@apx/parser` -- zero warnings; also ran the new `--html` flag against it end-to-end with no crash.
- [x] Docs updated: `docs/tutorial.md` 2.9 (new `--html` subsection, example, determinism note) and a one-line README mention under "Beyond M4."

Default `apx-coverage` text output is unchanged -- `--html` is purely additive.