### PR TITLE
Add apx-report — scoped CI dashboard (coverage + diff + parser warnings)

### DIFF
--- a/.ai/knowledge/generator.md
+++ b/.ai/knowledge/generator.md
@@ -63,11 +63,26 @@ generation; it never authors assertions — determinism is the product").
   rendered here would go unnoticed the same way `calendarSettings` once
   did for `apx-diff` — see `diff-field-coverage.test.ts`'s doc comment for
   the precedent this mirrors) plus a determinism check.
+- `src/report.ts` — `apx-report`: a self-contained HTML CI dashboard
+  bundling coverage + regression diff + a parser-warning summary into one
+  artifact (GitHub issue #3, `docs/ecosystem-roadmap.md` "Ninth round" "A
+  scoped-down CI dashboard"). No new analysis — pure composition of
+  already-real functions: `computeCoverage()`/`renderCoverageHtmlFragment()`
+  (coverage.ts/coverage-html.ts, embedded verbatim), `computeDiff()`/
+  `formatDiffHuman()` (diff.ts, embedded verbatim inside a `<pre>` block so
+  it can never drift from `apx-diff --format human`'s own output), and
+  `@apx/parser`'s own `ParseResult.warnings`. Deliberately does NOT include
+  screenshots, performance metrics, or accessibility results — none of
+  those exist anywhere in this project, so there's nothing real to bundle;
+  see the roadmap entry before proposing to add placeholder sections for
+  any of them. Same determinism contract as every other generated
+  artifact: same three inputs (old export dir, new export dir, touch log)
+  -> byte-identical HTML.
 - `src/lib.ts` — shared `loadExport()`/`generate()`/`inspect()`, also
   imported directly by `packages/mcp`.
-- `src/cli.ts` / `diff-cli.ts` / `coverage-cli.ts` / `docs-cli.ts` — the
-  four CLI entrypoints (`apx-generate`/equivalent, `apx-diff`,
-  `apx-coverage`, `apx-docs`).
+- `src/cli.ts` / `diff-cli.ts` / `coverage-cli.ts` / `docs-cli.ts` /
+  `report-cli.ts` — the five CLI entrypoints (`apx-generate`/equivalent,
+  `apx-diff`, `apx-coverage`, `apx-docs`, `apx-report`).
 
 ## `packages/mcp` (`@apx/mcp`)
 

--- a/README.md
+++ b/README.md
@@ -170,8 +170,10 @@ The pipeline is four packages wired together, AST-first:
                  apx-coverage CLI (touch log -> coverage report), the
                  apx-diff CLI (pure AST-to-AST regression report), the
                  apx-docs CLI (AST -> per-page Markdown docs, no live app),
-                 and the apx-flow CLI (AST -> Flow Map navigation graph
-                 JSON, no live app)
+                 the apx-flow CLI (AST -> Flow Map navigation graph
+                 JSON, no live app), and apx-report (self-contained HTML CI
+                 dashboard bundling coverage + diff + parser warnings -- no
+                 new analysis, pure composition of the above)
     ▼
 @apx/testkit   — the primitives BOTH generated and hand-written specs
                  import: item.ts (apex.item, VERIFIED), region.ts
@@ -279,6 +281,7 @@ not existing).
 | Regression detection (`apx-diff`) | — | ✅ (pure AST diff, no live app needed; `--format human` for prose output alongside the default structured tree) | — |
 | Documentation generation (`apx-docs`) | — | ✅ (pure AST read, no live app needed) | — |
 | Flow Map / navigation graph (`apx-flow`) | — | ✅ (pure AST read, no live app needed) — Phase 1a scope: `ApexPage.branches`, `ApexRegion.actions` (Cards/List), `ApexRegion.columns[].linkTarget`, `ApexButton.target`/`.url`. Every edge carries a real confidence tier: `'high'` (all 8 of 8 mechanisms — live-witnessed real data; button page/app-redirect targets were `'medium'` until the Fourteenth round corrected a false "zero real occurrences" claim that had only ever checked one app — `concurrent-manager` has 17 real `redirectThisApp` occurrences across 12 pages, `redirectOtherApp` specifically still unwitnessed). Breadcrumbs/navigation lists (shared-component parser support needed), dialog-page detection (cross-page join needed), Dynamic Action redirects (no declarative metadata found), and `apex.navigation` (runtime JS API) are all explicitly out of scope — see `docs/ecosystem-roadmap.md`'s Thirteenth and Fourteenth rounds | — |
+| CI dashboard (`apx-report`) | — | ✅ (self-contained HTML bundling coverage + diff + parser-warning-summary; no new data source, pure composition of the three rows above) | — |
 
 Full list of limitations in docs/limitations.md; a few of the stories
 behind specific rows:
@@ -380,7 +383,18 @@ docs/tutorial.md 2.9). Also done: `apx-docs <export-dir> --out
 row-level actions — dynamic actions, branches, validations, processes,
 computations) straight from the already-typed AST, no live app needed;
 see `docs/tutorial.md` §2.16 and `examples/employee-page/` for real
-output. Still open: snapshot testing (needs a masking-policy design), and
+output. Also done: `apx-report <old-export-dir> <new-export-dir>
+<touch-log-path> --out <report.html>` — a single self-contained HTML CI
+dashboard bundling coverage (embeds `renderCoverageHtmlFragment()`
+verbatim), regression diff (embeds `formatDiffHuman()` verbatim — the
+exact text `apx-diff --format human` prints), and a parser-warning
+summary (`@apx/parser`'s own `ParseResult.warnings`) in one artifact, safe
+to attach to a CI run. Deliberately scoped to exactly these three already-
+real data sources, not the larger coverage/diff/screenshots/perf/
+failures/a11y/parser-warnings pitch — screenshots, performance metrics,
+and accessibility results don't exist anywhere in this project yet, so
+there's nothing to compose them from; see docs/tutorial.md §2.17. Still
+open: snapshot testing (needs a masking-policy design), and
 Trees as content — the only Tree widget seen live so far is the universal
 left-nav reused for a login picker (see docs/ecosystem-roadmap.md), not a
 distinct page-content pattern.

--- a/docs/ecosystem-roadmap.md
+++ b/docs/ecosystem-roadmap.md
@@ -1943,15 +1943,25 @@ more careful split than the maintainer's own framing gives it.
   the maintainer's own framing ("the coverage data already computed")
   is accurate and is exactly the bar this project uses elsewhere for
   "buildable now." **Build now.**
-- **A scoped-down CI dashboard, from the larger item 16 pitch.** The full
-  `apx report` bundling coverage/diffs/screenshots/perf/failures/a11y/
-  parser-warnings is premature — three of those seven inputs
-  (screenshots, perf, a11y) don't exist yet (see below). But
-  coverage + diff + parser-warning-summary in one HTML output is three
-  already-real data sources with nothing new to verify. Worth scoping as
-  a small standalone item, not as the full seven-input bundle the
-  proposal describes — the smaller version is buildable now; the full
-  version isn't until its missing inputs exist.
+- **A scoped-down CI dashboard, from the larger item 16 pitch — DONE.**
+  Shipped as `apx-report` (`packages/generator/src/report.ts` +
+  `report-cli.ts`), a single self-contained HTML artifact bundling exactly
+  the three already-real data sources this entry called for: coverage
+  (embeds `renderCoverageHtmlFragment()` verbatim), regression diff
+  (embeds `formatDiffHuman()` verbatim, inside a `<pre>` block, so it can
+  never drift from what `apx-diff --format human` itself prints), and a
+  parser-warning summary (`@apx/parser`'s own `ParseResult.warnings`, the
+  same array `apx-testgen`/`apx-docs` already surface). No new analysis
+  anywhere in it — pure composition, same discipline as
+  `renderCoverageHtmlFragment()`'s own doc comment anticipated ("a future
+  scoped CI dashboard... is expected to embed this output rather than
+  shell out and re-parse text"). The full `apx report` bundling
+  coverage/diffs/screenshots/perf/failures/a11y/parser-warnings from the
+  original item 16 pitch remains premature — screenshots, performance
+  metrics, and accessibility results still don't exist anywhere in this
+  project (see below) — and this scoped version deliberately does not
+  stub in placeholder sections for any of them. See GitHub issue #3 and
+  `docs/tutorial.md` 2.17 for the full example and usage.
 
 ### The CRUD / Dynamic Action / Interactive Grid "recorder" idea (item 1) — three sub-questions, three different verdicts, not one
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -31,6 +31,7 @@ number of real apps, and honest about what doesn't work yet.
    - [2.15 Region actions (Cards/List row-level)](#215-region-actions-cardslist-row-level)
    - [2.16 Documentation generation](#216-documentation-generation)
    - [2.17 Flow Map (navigation graph)](#217-flow-map-navigation-graph)
+   - [2.18 CI dashboard](#218-ci-dashboard)
 3. [Page types & patterns](#3-page-types--patterns)
    - [3.1 Forms / data entry](#31-forms--data-entry)
    - [3.2 Reports](#32-reports)
@@ -1338,6 +1339,66 @@ deliberately NOT attempted, not a gap to work around:
 - A visual Flow Map UI — logged in `docs/ecosystem-roadmap.md`, deliberately
   unbuilt until a real user hits a concrete wall `apx-flow`'s JSON/CLI
   output can't solve.
+
+---
+
+### 2.18 CI dashboard
+
+**Status: VERIFIED**, and composes three already-verified pieces above —
+coverage mapping (2.9), regression detection (2.10), and the parser's own
+warning collection — into one self-contained HTML artifact, with no new
+analysis of its own:
+
+```bash
+node /path/to/apx-testkit/packages/generator/dist/report-cli.js \
+  <old-export-dir> <new-export-dir> <touch-log-path> --out apx-report.html
+```
+
+```
+CI dashboard written to apx-report.html
+  coverage -- items: 6/9 (67%), regions: 3/5 (60%), buttons: 1/1 (100%)
+  diff     -- 1 added, 0 removed, 1 changed, 4 unchanged
+  parser warnings -- 0
+```
+
+`<old-export-dir>`/`<new-export-dir>` are the same two directories you'd
+pass to `apx-diff` (2.10); `<touch-log-path>` is the same file
+`APX_COVERAGE_LOG` points your Playwright run at, read the same way
+`apx-coverage` (2.9) reads it. Coverage and the parser-warning summary are
+both computed against `<new-export-dir>` — the export a CI run is actually
+testing today, not the baseline it's being diffed against.
+
+The output is one file, no external CSS/JS/fonts, safe to open directly
+from disk or attach as a CI artifact. Three sections, in this order:
+
+- **Coverage** — `renderCoverageHtmlFragment()` (2.9) embedded verbatim:
+  the exact same summary cards, per-page heatmap, and untouched/
+  untrackable checklists `apx-coverage --html` produces on its own.
+- **Regression diff** — `formatDiffHuman()` (2.10) embedded verbatim
+  inside a `<pre>` block: the exact same prose `apx-diff --format human`
+  prints, byte-for-byte. Deliberately not re-rendered as a new HTML diff
+  view — embedding the existing text output guarantees this can never
+  drift from what the `apx-diff` CLI itself reports.
+- **Parser warnings** — every `ParseIssue` from `@apx/parser`'s own
+  `ParseResult.warnings` (the same array `apx-testgen`'s `--out` step and
+  `apx-docs` already surface to the console), one `<file>:<line> <message>`
+  entry per line, or a positive "No parser warnings" line when the export
+  parses clean.
+
+**Explicitly out of scope** (see `docs/ecosystem-roadmap.md` "Ninth
+round", "A scoped-down CI dashboard", and GitHub issue #3) — not stubbed
+in, not a placeholder: screenshots, performance metrics, and accessibility
+results. None of those exist anywhere in this project yet, so there is
+nothing real to bundle them from; adding empty sections for them would
+misrepresent what this dashboard actually checks.
+
+Same determinism guarantee as every other generated artifact in this
+project: the same three inputs (old export dir, new export dir, touch log)
+always render byte-identical HTML. `computeReport()`/`renderReportHtml()`/
+`renderReportHtmlFragment()` are exported from `@apx/testgen/report` for
+programmatic use (e.g. embedding this dashboard's markup into a larger
+host page, the same reuse `renderCoverageHtmlFragment()` was already
+built for — see 2.9).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4052,6 +4052,7 @@
         "apx-diff": "dist/diff-cli.js",
         "apx-docs": "dist/docs-cli.js",
         "apx-flow": "dist/flow-cli.js",
+        "apx-report": "dist/report-cli.js",
         "apx-testgen": "dist/cli.js"
       },
       "devDependencies": {

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -8,7 +8,8 @@
     "apx-coverage": "dist/coverage-cli.js",
     "apx-diff": "dist/diff-cli.js",
     "apx-docs": "dist/docs-cli.js",
-    "apx-flow": "dist/flow-cli.js"
+    "apx-flow": "dist/flow-cli.js",
+    "apx-report": "dist/report-cli.js"
   },
   "main": "dist/cli.js",
   "types": "dist/cli.d.ts",
@@ -44,6 +45,7 @@
     "./coverage-html": "./dist/coverage-html.js",
     "./diff": "./dist/diff.js",
     "./docs": "./dist/docs.js",
-    "./flow": "./dist/flow.js"
+    "./flow": "./dist/flow.js",
+    "./report": "./dist/report.js"
   }
 }

--- a/packages/generator/src/coverage-html.ts
+++ b/packages/generator/src/coverage-html.ts
@@ -5,9 +5,10 @@
  * docs/ecosystem-roadmap.md "Ninth round" for why this is scoped as a thin
  * rendering layer, not a new coverage engine.
  *
- * Two entry points, deliberately split for reuse (a future scoped CI
- * dashboard, tracked separately, is expected to embed this output rather
- * than shell out and re-parse text):
+ * Two entry points, deliberately split for reuse -- `report.ts`'s scoped
+ * CI dashboard (`apx-report`, GitHub issue #3) embeds `renderCoverageHtmlFragment()`
+ * directly rather than shelling out and re-parsing text, exactly as
+ * anticipated when this split was introduced:
  *
  * - `renderCoverageHtmlFragment()` -- the report content only, as a single
  *   `<section class="apx-coverage-report">`, with all styling scoped under
@@ -26,7 +27,14 @@
  */
 import type { CategoryCoverage, CoverageReport, PageCoverage, RegionCoverage } from './coverage.js';
 
-function escapeHtml(value: string): string {
+/**
+ * Exported (not just an internal helper) so `report.ts` -- the CI
+ * dashboard that composes this module's fragment alongside a diff section
+ * and a parser-warnings section -- can escape its own text content with
+ * the exact same rules, rather than re-implementing an equivalent
+ * function. No behavior change for this module's own use below.
+ */
+export function escapeHtml(value: string): string {
   return value
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')

--- a/packages/generator/src/report-cli.ts
+++ b/packages/generator/src/report-cli.ts
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+import { existsSync, writeFileSync } from 'node:fs';
+import { computeReport, renderReportHtml } from './report.js';
+
+const args = process.argv.slice(2);
+const oldExportDir = args[0];
+const newExportDir = args[1];
+const touchLogPath = args[2];
+const outIdx = args.indexOf('--out');
+const outPath = outIdx >= 0 ? args[outIdx + 1] : './apx-report.html';
+
+if (!oldExportDir || !newExportDir || !touchLogPath) {
+  console.error(
+    'Usage: apx-report <old-export-dir> <new-export-dir> <touch-log-path> [--out <report.html>]',
+  );
+  console.error('  Bundles three already-real reports into one self-contained HTML dashboard:');
+  console.error('    - coverage (same data as `apx-coverage --html`), computed against <new-export-dir>');
+  console.error('      and <touch-log-path> -- see docs/tutorial.md 2.9 for how to record a touch log.');
+  console.error('    - regression diff (same data as `apx-diff --format human`), between <old-export-dir>');
+  console.error('      and <new-export-dir>.');
+  console.error('    - a parser-warning summary for <new-export-dir> (@apx/parser\'s own ParseResult.warnings).');
+  console.error('  --out defaults to ./apx-report.html.');
+  process.exit(2);
+}
+if (outIdx >= 0 && !args[outIdx + 1]) {
+  console.error('--out requires an output path, e.g. --out apx-report.html');
+  process.exit(2);
+}
+if (!existsSync(oldExportDir)) {
+  console.error(`Old export directory not found: ${oldExportDir}`);
+  process.exit(2);
+}
+if (!existsSync(newExportDir)) {
+  console.error(`New export directory not found: ${newExportDir}`);
+  process.exit(2);
+}
+if (!existsSync(touchLogPath)) {
+  console.error(
+    `Warning: touch log ${touchLogPath} does not exist -- every item/region/button in the coverage ` +
+      'section will show as untouched. Did you set APX_COVERAGE_LOG before running the suite? ' +
+      '(See docs/tutorial.md 2.9.)',
+  );
+}
+
+const report = computeReport(oldExportDir, newExportDir, touchLogPath);
+
+if (report.parserWarnings.length > 0) {
+  console.error(`Parser warnings (${report.parserWarnings.length}) -- dashboard still generated:`);
+  for (const w of report.parserWarnings.slice(0, 20)) console.error(`  ${w.loc.file}:${w.loc.line} ${w.message}`);
+}
+
+writeFileSync(outPath, renderReportHtml(report));
+
+const c = report.coverage.overall;
+const pct = (touched: number, total: number): string => (total === 0 ? 'n/a' : `${Math.round((touched / total) * 100)}%`);
+const s = report.diff.summary;
+
+console.log(`CI dashboard written to ${outPath}`);
+console.log(
+  `  coverage -- items: ${c.items.touched}/${c.items.total} (${pct(c.items.touched, c.items.total)}), ` +
+    `regions: ${c.regions.touched}/${c.regions.total} (${pct(c.regions.touched, c.regions.total)}), ` +
+    `buttons: ${c.buttons.touched}/${c.buttons.total} (${pct(c.buttons.touched, c.buttons.total)})`,
+);
+console.log(
+  `  diff     -- ${s.pagesAdded} added, ${s.pagesRemoved} removed, ${s.pagesChanged} changed, ${s.pagesUnchanged} unchanged`,
+);
+console.log(`  parser warnings -- ${report.parserWarnings.length}`);

--- a/packages/generator/src/report.ts
+++ b/packages/generator/src/report.ts
@@ -1,0 +1,177 @@
+/**
+ * apx-report — a single, self-contained HTML "CI dashboard" bundling three
+ * already-real data sources into one artifact: coverage (`apx-coverage`,
+ * PR #11), regression diff (`apx-diff --format human`, PR #10), and a
+ * parser-warning summary (`@apx/parser`'s own `ParseResult.warnings`). See
+ * GitHub issue #3 and `docs/ecosystem-roadmap.md` "Ninth round" ("A
+ * scoped-down CI dashboard, from the larger item 16 pitch") for why this is
+ * scoped to exactly these three inputs and not the larger
+ * coverage/diff/screenshots/perf/failures/a11y/parser-warnings pitch:
+ * screenshots, performance metrics, and accessibility results don't exist
+ * anywhere in this project yet, so there is nothing real to compose them
+ * from -- adding placeholder sections for them would misrepresent this as
+ * having more coverage than it does.
+ *
+ * This module does NO new analysis of its own:
+ *   - Coverage: `computeCoverage()` (`coverage.ts`, unchanged) computes the
+ *     report; `renderCoverageHtmlFragment()` (`coverage-html.ts`, unchanged
+ *     -- exported specifically for this reuse, see its own doc comment)
+ *     renders it. Embedded verbatim.
+ *   - Diff: `computeDiff()` (`diff.ts`, unchanged) computes the report;
+ *     `formatDiffHuman()` (`diff.ts`, unchanged -- the exact function
+ *     backing `apx-diff --format human`) renders it as prose. Embedded
+ *     verbatim inside a `<pre>` block -- deliberately NOT re-implemented as
+ *     a new HTML diff renderer here, so this can never drift from what
+ *     `apx-diff --format human` itself prints.
+ *   - Parser warnings: `@apx/parser`'s `parseApp()` already collects these
+ *     (`ParseResult.warnings`, `ParseIssue { message, loc: { file, line } }`)
+ *     -- the exact same array `apx-testgen`'s `generate()`/`inspect()`
+ *     already surface (`lib.ts`) and print as `<file>:<line> <message>`.
+ *     Formatted here as a plain list, same string shape, nothing new.
+ *
+ * Determinism: same three inputs (old export dir, new export dir, touch
+ * log) -> byte-identical HTML, every time -- no timestamps, no
+ * non-deterministic ordering beyond what `computeDiff()`/`computeCoverage()`/
+ * `parseApp()` themselves already guarantee.
+ */
+import { resolve } from 'node:path';
+import { parseApp, type ParseIssue } from '@apx/parser';
+import { computeCoverage, type CoverageReport } from './coverage.js';
+import { COVERAGE_HTML_STYLE, escapeHtml, renderCoverageHtmlFragment } from './coverage-html.js';
+import { computeDiff, formatDiffHuman, type DiffReport } from './diff.js';
+import { loadExport } from './lib.js';
+
+export interface DashboardReport {
+  oldExportDir: string;
+  newExportDir: string;
+  touchLogPath: string;
+  diff: DiffReport;
+  coverage: CoverageReport;
+  /**
+   * Parser warnings for `newExportDir` -- the export the coverage report
+   * and the "new" side of the diff both already read from, so warnings
+   * are reported against the same export a CI run would actually be
+   * testing today, not the baseline it's being compared against.
+   */
+  parserWarnings: ParseIssue[];
+}
+
+/**
+ * Assembles the three already-real reports this dashboard bundles. Each
+ * sub-report is computed by its own existing, unmodified function --
+ * this performs no analysis of its own, only composition.
+ */
+export function computeReport(oldExportDir: string, newExportDir: string, touchLogPath: string): DashboardReport {
+  const diff = computeDiff(oldExportDir, newExportDir);
+  const coverage = computeCoverage(newExportDir, touchLogPath);
+  const parserWarnings = parseApp(loadExport(resolve(newExportDir))).warnings;
+  return {
+    oldExportDir: resolve(oldExportDir),
+    newExportDir: resolve(newExportDir),
+    touchLogPath: resolve(touchLogPath),
+    diff,
+    coverage,
+    parserWarnings,
+  };
+}
+
+const STYLE = `
+.apx-report { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; color: #1a1a1a; background: #ffffff; padding: 1rem; color-scheme: light; }
+.apx-report h1 { font-size: 1.6rem; margin: 0 0 0.25rem; }
+.apx-report h2 { font-size: 1.2rem; margin: 1.75rem 0 0.5rem; border-bottom: 1px solid #ddd; padding-bottom: 0.25rem; }
+.apx-report .apx-report-meta { color: #555; font-size: 0.85rem; margin: 0 0 1rem; }
+.apx-report .apx-report-section { margin-bottom: 1rem; }
+.apx-report .apx-report-diff-pre { background: #f6f8fa; border: 1px solid #ddd; border-radius: 6px; padding: 0.75rem 1rem; font-size: 0.8rem; line-height: 1.4; overflow-x: auto; white-space: pre-wrap; word-break: break-word; margin: 0.5rem 0 0; }
+.apx-report ul.apx-report-warnings-list { font-size: 0.85rem; padding-left: 1.25rem; margin: 0.5rem 0 0; }
+.apx-report ul.apx-report-warnings-list li { padding: 0.15rem 0; color: #7a3e00; }
+.apx-report .apx-report-warnings-empty { color: #1a7f37; font-weight: 600; margin: 0.5rem 0 0; }
+`.trim();
+
+/**
+ * The exact `<style>` contents `renderReportHtml()` embeds for this
+ * module's OWN sections (diff/warnings/header) -- exported for the same
+ * reason `COVERAGE_HTML_STYLE` is: a host page embedding
+ * `renderReportHtmlFragment()` needs it too. Does not include
+ * `COVERAGE_HTML_STYLE` itself; a consumer embedding the coverage section
+ * must supply that separately (re-exported for convenience -- see below).
+ */
+export const REPORT_HTML_STYLE = STYLE;
+
+function renderCoverageSection(report: CoverageReport): string {
+  return `<div class="apx-report-section apx-report-section-coverage">
+  <h2>Coverage</h2>
+  ${renderCoverageHtmlFragment(report)}
+</div>`;
+}
+
+function renderDiffSection(report: DiffReport): string {
+  return `<div class="apx-report-section apx-report-section-diff">
+  <h2>Regression diff</h2>
+  <p class="apx-report-meta">old: ${escapeHtml(report.oldExportDir)}<br>new: ${escapeHtml(report.newExportDir)}</p>
+  <pre class="apx-report-diff-pre">${escapeHtml(formatDiffHuman(report))}</pre>
+</div>`;
+}
+
+function renderWarningsSection(warnings: readonly ParseIssue[]): string {
+  if (warnings.length === 0) {
+    return `<div class="apx-report-section apx-report-section-warnings">
+  <h2>Parser warnings</h2>
+  <p class="apx-report-warnings-empty">&#10003; No parser warnings.</p>
+</div>`;
+  }
+  const items = warnings
+    .map((w) => `<li>${escapeHtml(w.loc.file)}:${w.loc.line} ${escapeHtml(w.message)}</li>`)
+    .join('');
+  return `<div class="apx-report-section apx-report-section-warnings">
+  <h2>Parser warnings (${warnings.length})</h2>
+  <ul class="apx-report-warnings-list">${items}</ul>
+</div>`;
+}
+
+/**
+ * Renders the dashboard content only -- a single
+ * `<section class="apx-report">`, safe to inline into a host page's own
+ * DOM. The host page must supply both `REPORT_HTML_STYLE` (this module's
+ * own diff/warnings/header rules) AND `COVERAGE_HTML_STYLE` (re-exported
+ * below) -- this function emits no `<style>` tag itself, matching
+ * `renderCoverageHtmlFragment()`'s own contract.
+ */
+export function renderReportHtmlFragment(report: DashboardReport): string {
+  return `<section class="apx-report">
+  <h1>APX CI Dashboard</h1>
+  <p class="apx-report-meta">new export: ${escapeHtml(report.newExportDir)}<br>
+  baseline export: ${escapeHtml(report.oldExportDir)}<br>
+  touch log: ${escapeHtml(report.touchLogPath)}</p>
+
+  ${renderCoverageSection(report.coverage)}
+  ${renderDiffSection(report.diff)}
+  ${renderWarningsSection(report.parserWarnings)}
+</section>`;
+}
+
+/** Re-exported so a single import of `report.js` has everything needed to embed `renderReportHtmlFragment()`'s output (both this module's own styles and the coverage fragment's). */
+export { COVERAGE_HTML_STYLE };
+
+/**
+ * Renders a complete, standalone HTML document -- own `<head>`/`<style>`
+ * (this module's rules plus `COVERAGE_HTML_STYLE`), no external
+ * stylesheets, fonts, or scripts. Safe to open directly from disk
+ * (`file://`) or attach as a CI artifact -- the actual point of this CLI.
+ */
+export function renderReportHtml(report: DashboardReport): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>APX CI Dashboard</title>
+<style>
+${REPORT_HTML_STYLE}
+${COVERAGE_HTML_STYLE}
+</style>
+</head>
+<body style="margin: 0; background: #ffffff;">
+${renderReportHtmlFragment(report)}
+</body>
+</html>
+`;
+}

--- a/packages/generator/test/report.test.ts
+++ b/packages/generator/test/report.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for apx-report (packages/generator/src/report.ts) — GitHub issue
+ * #3, docs/ecosystem-roadmap.md "Ninth round" ("A scoped-down CI
+ * dashboard"). Two concerns, matching the split already established by
+ * coverage-html.test.ts (synthetic-fixture rendering tests) and
+ * docs.test.ts (a real-export integration test against the committed
+ * reference fixture):
+ *
+ *   1. Rendering — hand-built `DashboardReport` fixtures (no filesystem),
+ *      exercising `renderReportHtml`/`renderReportHtmlFragment` directly,
+ *      the same way `coverage-html.test.ts` drives `CoverageReport`
+ *      fixtures and `diff-human.test.ts` drives `DiffReport` fixtures —
+ *      this module does no new analysis, so there's nothing to test here
+ *      except "does it render what's already computed, correctly and
+ *      deterministically."
+ *   2. Wiring — `computeReport()` against the real committed
+ *      `fixtures/reference-fixtures` export (the same fixture
+ *      `docs.test.ts`'s own real-export tests use), confirming it actually
+ *      calls `computeDiff`/`computeCoverage`/`parseApp` and assembles their
+ *      results, not just that the pure rendering functions work in
+ *      isolation.
+ */
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ParseIssue } from '@apx/parser';
+import type { CoverageReport } from '../src/coverage.js';
+import type { DiffReport } from '../src/diff.js';
+import {
+  COVERAGE_HTML_STYLE,
+  REPORT_HTML_STYLE,
+  computeReport,
+  renderReportHtml,
+  renderReportHtmlFragment,
+  type DashboardReport,
+} from '../src/report.js';
+
+function coverageFixture(overrides: Partial<CoverageReport> = {}): CoverageReport {
+  return {
+    exportDir: '/tmp/export',
+    touchLogPath: '/tmp/coverage.jsonl',
+    touchCount: 0,
+    pages: [],
+    overall: {
+      items: { total: 0, touched: 0, untouched: [] },
+      regions: { total: 0, touched: 0, untouched: [], untrackable: [] },
+      buttons: { total: 0, touched: 0, untouched: [] },
+    },
+    ...overrides,
+  };
+}
+
+function diffFixture(overrides: Partial<DiffReport> = {}): DiffReport {
+  return {
+    oldExportDir: '/tmp/old-export',
+    newExportDir: '/tmp/new-export',
+    pages: [],
+    summary: { pagesAdded: 0, pagesRemoved: 0, pagesChanged: 0, pagesUnchanged: 3 },
+    ...overrides,
+  };
+}
+
+function reportFixture(overrides: Partial<DashboardReport> = {}): DashboardReport {
+  return {
+    oldExportDir: '/tmp/old-export',
+    newExportDir: '/tmp/new-export',
+    touchLogPath: '/tmp/coverage.jsonl',
+    diff: diffFixture(),
+    coverage: coverageFixture(),
+    parserWarnings: [],
+    ...overrides,
+  };
+}
+
+describe('renderReportHtml / renderReportHtmlFragment — rendering', () => {
+  it('is deterministic -- same report renders byte-identical HTML every call', () => {
+    const r = reportFixture();
+    expect(renderReportHtml(r)).toBe(renderReportHtml(r));
+    expect(renderReportHtmlFragment(r)).toBe(renderReportHtmlFragment(r));
+  });
+
+  it('renderReportHtml wraps a full standalone document; the fragment does not', () => {
+    const r = reportFixture();
+    const full = renderReportHtml(r);
+    const fragment = renderReportHtmlFragment(r);
+
+    expect(full).toContain('<!doctype html>');
+    expect(full).toContain('<style>');
+    expect(full).toContain(fragment);
+
+    expect(fragment).not.toContain('<!doctype html>');
+    expect(fragment).not.toContain('<html');
+    expect(fragment).not.toContain('<style>');
+    expect(fragment.startsWith('<section class="apx-report">')).toBe(true);
+  });
+
+  it('the full document embeds both this module\'s own style and the reused coverage style, unmodified', () => {
+    const full = renderReportHtml(reportFixture());
+    expect(full).toContain(REPORT_HTML_STYLE);
+    expect(full).toContain(COVERAGE_HTML_STYLE);
+  });
+
+  it('embeds the coverage section via renderCoverageHtmlFragment verbatim (byte-for-byte, not re-derived)', async () => {
+    const { renderCoverageHtmlFragment } = await import('../src/coverage-html.js');
+    const coverage = coverageFixture({ touchCount: 5, exportDir: '/tmp/my-export' });
+    const html = renderReportHtmlFragment(reportFixture({ coverage }));
+    expect(html).toContain(renderCoverageHtmlFragment(coverage));
+  });
+
+  it('embeds the diff section via formatDiffHuman verbatim (byte-for-byte, not re-derived)', async () => {
+    const { formatDiffHuman } = await import('../src/diff.js');
+    const diff = diffFixture({ summary: { pagesAdded: 2, pagesRemoved: 0, pagesChanged: 1, pagesUnchanged: 4 } });
+    const html = renderReportHtmlFragment(reportFixture({ diff }));
+    const escaped = formatDiffHuman(diff)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+    expect(html).toContain(escaped);
+  });
+
+  it('reports "no parser warnings" positively when the array is empty', () => {
+    const html = renderReportHtmlFragment(reportFixture({ parserWarnings: [] }));
+    expect(html).toContain('No parser warnings.');
+    expect(html).not.toContain('apx-report-warnings-list');
+  });
+
+  it('lists every parser warning as file:line message, with a count in the heading', () => {
+    const warnings: ParseIssue[] = [
+      { message: 'Unrecognized line: "foo"', loc: { file: 'pages/p00003-employee.apx', line: 12 } },
+      { message: 'Unterminated block \'region\'', loc: { file: 'application.apx', line: 4 } },
+    ];
+    const html = renderReportHtmlFragment(reportFixture({ parserWarnings: warnings }));
+    expect(html).toContain('Parser warnings (2)');
+    expect(html).toContain('pages/p00003-employee.apx:12 Unrecognized line: &quot;foo&quot;');
+    expect(html).toContain('application.apx:4 Unterminated block &#39;region&#39;');
+    expect(html).not.toContain('No parser warnings.');
+  });
+
+  it('escapes HTML-significant characters in export dir paths and warning messages', () => {
+    const html = renderReportHtmlFragment(
+      reportFixture({
+        newExportDir: '/tmp/<new> & "export"',
+        parserWarnings: [{ message: 'bad <tag> & stuff', loc: { file: 'p.apx', line: 1 } }],
+      }),
+    );
+    expect(html).toContain('/tmp/&lt;new&gt; &amp; &quot;export&quot;');
+    expect(html).toContain('bad &lt;tag&gt; &amp; stuff');
+    expect(html).not.toContain('/tmp/<new> & "export"');
+    expect(html).not.toContain('bad <tag> & stuff');
+  });
+
+  it('includes the touch log path and the old/new export dirs in the header meta', () => {
+    const html = renderReportHtmlFragment(
+      reportFixture({ oldExportDir: '/tmp/old', newExportDir: '/tmp/new', touchLogPath: '/tmp/touch.jsonl' }),
+    );
+    expect(html).toContain('/tmp/old');
+    expect(html).toContain('/tmp/new');
+    expect(html).toContain('/tmp/touch.jsonl');
+  });
+
+  it('does NOT contain any screenshot/performance/accessibility section -- explicitly out of scope', () => {
+    const html = renderReportHtml(reportFixture());
+    for (const term of ['screenshot', 'performance', 'accessibility', 'a11y']) {
+      expect(html.toLowerCase()).not.toContain(term);
+    }
+  });
+});
+
+describe('computeReport — against the real committed reference fixture', () => {
+  const exportDir = join(__dirname, 'fixtures', 'reference-fixtures');
+
+  it('assembles diff (self-diff, zero changes), coverage, and parser warnings from the real export', () => {
+    const touchLogDir = mkdtempSync(join(tmpdir(), 'apx-report-test-'));
+    const touchLogPath = join(touchLogDir, 'coverage.jsonl');
+    writeFileSync(touchLogPath, '');
+    try {
+      const report = computeReport(exportDir, exportDir, touchLogPath);
+
+      // Diff: comparing the export against itself -> zero changes.
+      expect(report.diff.summary).toEqual({ pagesAdded: 0, pagesRemoved: 0, pagesChanged: 0, pagesUnchanged: 1 });
+      expect(report.diff.pages).toEqual([]);
+
+      // Coverage: real declared items/regions/buttons from the fixture, nothing touched (empty log).
+      expect(report.coverage.overall.items.total).toBeGreaterThan(0);
+      expect(report.coverage.overall.items.touched).toBe(0);
+
+      // Parser warnings: the committed fixture is known-clean (regression sweep requires this).
+      expect(report.parserWarnings).toEqual([]);
+
+      expect(report.oldExportDir).toContain('reference-fixtures');
+      expect(report.newExportDir).toContain('reference-fixtures');
+    } finally {
+      rmSync(touchLogDir, { recursive: true, force: true });
+    }
+  });
+
+  it('renderReportHtml(computeReport(...)) is deterministic end-to-end -- byte-identical across two independent runs', () => {
+    const touchLogDir = mkdtempSync(join(tmpdir(), 'apx-report-test-'));
+    const touchLogPath = join(touchLogDir, 'coverage.jsonl');
+    writeFileSync(touchLogPath, '{"kind":"item","identifier":"P3_ENAME"}\n');
+    try {
+      const html1 = renderReportHtml(computeReport(exportDir, exportDir, touchLogPath));
+      const html2 = renderReportHtml(computeReport(exportDir, exportDir, touchLogPath));
+      expect(html1).toBe(html2);
+    } finally {
+      rmSync(touchLogDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #3

## Summary

Adds `apx-report`, a new CLI (`packages/generator/src/report.ts` +
`report-cli.ts`) that bundles three already-real, already-merged data
sources into a single self-contained HTML "CI dashboard" artifact:

- **Coverage** — embeds `renderCoverageHtmlFragment()` (`coverage-html.ts`,
  PR #11) verbatim, computed against `<new-export-dir>` + the touch log.
- **Regression diff** — embeds `formatDiffHuman()` (`diff.ts`, PR #10)
  verbatim inside a `<pre>` block — the exact prose `apx-diff --format
  human` prints between `<old-export-dir>` and `<new-export-dir>`, so this
  can never drift from that CLI's own output.
- **Parser-warning summary** — `@apx/parser`'s own `ParseResult.warnings`
  for `<new-export-dir>`, the same array `apx-testgen`/`apx-docs` already
  surface, rendered as `<file>:<line> <message>` (or a positive "No parser
  warnings" line).

This module does **no new analysis** — every fact rendered already exists
on `DiffReport`/`CoverageReport`/`ParseResult`; it's pure composition,
matching this project's existing `coverage-html.ts`/`diff.ts` conventions
(inline CSS, no external assets, byte-identical output for the same
inputs).

Explicitly **out of scope**, per the original issue and the roadmap
evaluation: screenshots, performance metrics, and accessibility results.
None of those exist anywhere in this project yet, so no placeholder
sections were added for them.

```bash
node packages/generator/dist/report-cli.js \
  <old-export-dir> <new-export-dir> <touch-log-path> --out apx-report.html
```

Docs updated together: `README.md` capability matrix + architecture
diagram + "Beyond M4" section, `docs/tutorial.md` §2.17 (new), and
`docs/ecosystem-roadmap.md` (the "scoped-down CI dashboard" item marked
DONE in place, matching how the diff/coverage items were closed out).

## Test plan

- [x] `npm run build --workspaces` (parser → testkit → generator → mcp, in
      dependency order) — zero errors
- [x] `npm test --workspaces` — full vitest suite, including 12 new tests
      in `packages/generator/test/report.test.ts` (rendering fixtures +
      escaping + a real-export integration test against the committed
      `reference-fixtures` fixture) — 199/199 passing in `generator`,
      269 total across all packages
- [x] `npm run lint` — clean
- [x] `cd spike && npx tsc --noEmit` — clean
- [x] Regenerated `packages/generator/test/fixtures/reference-fixtures`
      (both `apx-testgen` and `apx-docs`) and diffed against committed
      `examples/employee-page` — byte-identical
- [x] New determinism check for this feature specifically: ran
      `apx-report` twice against the same three inputs and diffed the
      HTML output — byte-identical
- [x] Manually inspected the generated HTML (coverage heatmap, diff `<pre>`
      block, warnings section) for correct structure/escaping