### PR TITLE
fix(parser): stop requiring two properties real Oracle exports never set

### DIFF
--- a/docs/grammar-assumptions.md
+++ b/docs/grammar-assumptions.md
@@ -49,6 +49,54 @@ is verified, what changed vs. the docs-derived guesses, and what remains open.
       zero warnings, the correct unquoted identifier, the region's type
       surviving uncorrupted, and the trailing button not being orphaned) —
       confirmed the test fails all four ways on the pre-fix regex.
+- [x] **`page`'s component-id IS its own page number; the interior `page: N`
+      property the EBNF marks "required" is NOT present in real exports.**
+      `<page-direct-property> ::= "page" ":" <ws> <number> (* required *)` in
+      Oracle's own published EBNF — but oracle/apex's 26.1
+      `sample-reporting` app (`pages/p00001-interactive-report.apx`, fetched
+      directly from GitHub) opens `page 1 (` followed immediately by
+      `name: Interactive Report`, no interior `page:` line anywhere in the
+      895-line file except two unrelated `target: { page: N }` branch/link
+      redirect targets (lines 101, 858). Confirmed independently by a real
+      user's SQLcl 26.2.1 export failing for the same reason (GitHub issue
+      #21) — this project's own parser previously threw
+      `page 'N' is missing a valid integer 'page:' property` on every page of
+      every real export, because `projectPages()` only ever read the
+      interior property and never the component-id already captured as
+      `ComponentNode.identifier`. Fixed: the page number is now derived from
+      the component-id (parsed as a plain non-negative integer) first, with
+      the interior property — when present, as in this project's own
+      hand-written fixtures, which redundantly set both — used only as a
+      consistency cross-check (a mismatch between the two throws loudly,
+      never silently resolved one way). EBNF-vs-reality discrepancy, real
+      data wins per this file's own precedent (see the `calendarSettings`
+      entry below) — not filed as a `docs/quirks/26.1.json` entry because
+      that ledger is explicitly scoped to live-instance findings; this is a
+      static-export/parser finding instead.
+- [x] **`app-runtime-group-is-optional`: the app-level `runtime { }` group
+      (and the `friendlyUrls` property inside it) may be entirely absent
+      from a real export.** The EBNF lists `<app-runtime>` as one of ~20
+      OPTIONAL sibling group blocks under `<app>` (`javaScript`, `css`,
+      `authentication`, `security`, ... — clearly not all always present),
+      and marks `friendlyUrls` "required" only WITHIN that group, the same
+      shape as the page-number finding above. Confirmed real: oracle/apex's
+      26.1 `sample-reporting` app export (the exact app in GitHub issue
+      #21) has no `runtime { }` block anywhere in its `application.apx`.
+      This project's own parser previously hard-threw
+      `app '...' is missing required boolean 'runtime.friendlyUrls'` on
+      every app missing the group — meaning the SAME real app that
+      triggered the page-number bug above would have failed a SECOND time,
+      immediately after the first fix, on the exact same reported issue.
+      Fixed: `ApexApplication.runtime.friendlyUrls` is now typed
+      `boolean | null` (`null` = not declared, never coerced to a guessed
+      boolean, per this project's own §22-style "unknown, don't guess"
+      discipline). Downstream consumers (`page-object.ts`'s URL
+      construction) already had a safe `?? true` fallback for a missing
+      `application` entirely; `null` flows through that same fallback
+      correctly with no further change needed. Verified end-to-end against
+      the complete real 42-page `sample-reporting` export, fetched fresh
+      from GitHub: `apx-testgen` now generates all 42 page objects + specs
+      with zero warnings, where it previously failed to parse at all.
 - [x] Global page 0 exists with no alias; page files p00000-... zero-padded 5.
 - [x] Package layout: application.apx, page-groups.apx, pages/, shared-
       components/ (with themes/ + static-files/ native assets), .apex/

--- a/packages/parser/src/ast.ts
+++ b/packages/parser/src/ast.ts
@@ -61,7 +61,14 @@ export interface ApexApplication {
   version: string | null;
   type: string | null;
   runtime: {
-    friendlyUrls: boolean;
+    /** `null` when the app's `runtime { }` group is absent entirely --
+     * confirmed real: the EBNF lists `runtime` as one of many OPTIONAL
+     * group blocks under `app` (siblings: `javaScript`, `css`,
+     * `authentication`, ...), and oracle/apex's own 26.1 `sample-reporting`
+     * app export has no `runtime { }` block at all. `null` means "not
+     * declared," not "false" -- do not treat it as a legacy-URL signal.
+     * See docs/grammar-assumptions.md `app-runtime-group-is-optional`. */
+    friendlyUrls: boolean | null;
     compatibilityMode: string | null;
   };
   loc: Loc;
@@ -69,8 +76,14 @@ export interface ApexApplication {
 }
 
 export interface ApexPage {
-  /** Permanent APEXlang component identifier; distinct from the numeric page property. */
+  /** The `page <N> (` opening-line component-id. For pages specifically
+   * this IS the page's own numeric page number as a string (e.g. `page 1 (`
+   * -> "1"), confirmed against real Oracle-generated exports -- NOT a
+   * separate developer-facing name (that's `alias` below). `id` is derived
+   * from this field; see its own doc comment and docs/quirks/26.1.json
+   * `page-number-not-required-property`. */
   identifier: string | null;
+  /** The page number, as `Number(identifier)`. */
   id: number;
   alias: string | null;
   name: string | null;

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -629,10 +629,14 @@ export function projectPages(roots: ComponentNode[]): {
   let application: ApexAppAst['application'] = null;
   for (const n of roots) {
     if (n.type === 'app') {
+      // `runtime { }` is one of many OPTIONAL group blocks under `app` in
+      // the EBNF (siblings: javaScript, css, authentication, ...) -- not
+      // every real export declares it. Confirmed absent entirely in
+      // oracle/apex's own 26.1 sample-reporting app. `friendlyUrls: null`
+      // means "not declared," never coerced to a guessed boolean -- see
+      // ApexApplication.runtime's doc comment and docs/grammar-assumptions.md
+      // `app-runtime-group-is-optional`.
       const friendlyUrls = bool(n.props['runtime.friendlyUrls']);
-      if (friendlyUrls === null) {
-        throw new Error(`${n.loc.file}:${n.loc.line}: app '${n.identifier ?? '(anonymous)'}' is missing required boolean 'runtime.friendlyUrls'.`);
-      }
       application = {
         identifier: n.identifier,
         name: str(n.props['name']),
@@ -651,9 +655,26 @@ export function projectPages(roots: ComponentNode[]): {
     if (n.type === '#comment') continue;
     if (n.type !== 'page') { unmodeled.add(n.type); continue; }
 
-    const pageId = num(n.props['page']);
+    // Page number derivation: `page <N> (` -- the component-id captured as
+    // `n.identifier` -- confirmed live to BE the page's own numeric page
+    // number (e.g. `page 1 (` -> identifier "1"). The official EBNF marks an
+    // interior `page: N` direct property "required", but real Oracle-generated
+    // exports never include it -- confirmed against oracle/apex's own 26.1
+    // sample-reporting app (`pages/p00001-interactive-report.apx`), which
+    // opens with `page 1 (` followed immediately by `name: ...`, no interior
+    // `page:` line anywhere in the file except unrelated branch/link redirect
+    // targets (`target: { page: N }`). See docs/quirks/26.1.json
+    // `page-number-not-required-property`. The interior property is used only
+    // as an optional consistency cross-check when present (this project's own
+    // hand-written fixtures redundantly set both).
+    const idFromComponentId = n.identifier !== null && /^\d+$/.test(n.identifier) ? Number(n.identifier) : null;
+    const idFromInteriorProp = num(n.props['page']);
+    if (idFromComponentId !== null && idFromInteriorProp !== null && idFromComponentId !== idFromInteriorProp) {
+      throw new Error(`${n.loc.file}:${n.loc.line}: page's component-id (${idFromComponentId}) contradicts its interior 'page:' property (${idFromInteriorProp}) -- these must agree.`);
+    }
+    const pageId = idFromComponentId ?? idFromInteriorProp;
     if (pageId === null || !Number.isInteger(pageId) || pageId < 0) {
-      throw new Error(`${n.loc.file}:${n.loc.line}: page '${n.identifier ?? '(anonymous)'}' is missing a valid integer 'page:' property.`);
+      throw new Error(`${n.loc.file}:${n.loc.line}: page '${n.identifier ?? '(anonymous)'}' has no derivable page number -- its component-id is not a plain non-negative integer, and no interior 'page:' property provides one either.`);
     }
 
     const regionNodes = n.children.filter((c) => c.type === 'region');

--- a/packages/parser/test/parser.test.ts
+++ b/packages/parser/test/parser.test.ts
@@ -1043,13 +1043,23 @@ describe('Oracle-documented page identity and lexical values', () => {
     });
   });
 
-  it('rejects an app whose required friendlyUrls property is missing or not boolean', () => {
-    expect(() => parseApp({
+  it('represents friendlyUrls as null (unknown), never a guessed boolean, when the runtime group is absent or malformed', () => {
+    // `runtime { }` is one of many OPTIONAL group blocks under `app` in the
+    // EBNF (siblings: javaScript, css, authentication, ...) -- confirmed
+    // real: oracle/apex's own 26.1 sample-reporting app export has no
+    // `runtime { }` block at all (GitHub issue #21's reported app). This
+    // must NOT throw; friendlyUrls must NOT be silently coerced to a
+    // boolean either. See docs/grammar-assumptions.md
+    // `app-runtime-group-is-optional`.
+    expect(parseApp({
+      'application.apx': 'app example (\n  name: Example\n  alias: EXAMPLE\n)',
+    }).ast.application).toMatchObject({ runtime: { friendlyUrls: null } });
+    expect(parseApp({
       'application.apx': 'app example (\n  runtime {\n    compatibilityMode: "26.1"\n  }\n)',
-    })).toThrow(/required boolean 'runtime\.friendlyUrls'/);
-    expect(() => parseApp({
+    }).ast.application).toMatchObject({ runtime: { friendlyUrls: null, compatibilityMode: '26.1' } });
+    expect(parseApp({
       'application.apx': 'app example (\n  runtime {\n    friendlyUrls: "false"\n    compatibilityMode: "26.1"\n  }\n)',
-    })).toThrow(/required boolean 'runtime\.friendlyUrls'/);
+    }).ast.application).toMatchObject({ runtime: { friendlyUrls: null } });
   });
 
   it('uses the required page property rather than the component identifier', () => {
@@ -1077,9 +1087,30 @@ describe('Oracle-documented page identity and lexical values', () => {
     expect(result.ast.pages[0].raw['P#EDIT"PAGE#_ID']).toBe('value');
   });
 
-  it('rejects a missing or invalid page property', () => {
-    expect(() => parseApp({ 'missing.apx': 'page example (\n  name: Example\n)' })).toThrow(/missing a valid integer 'page:' property/);
-    expect(() => parseApp({ 'invalid.apx': 'page example (\n  page: nope\n  name: Example\n)' })).toThrow(/missing a valid integer 'page:' property/);
+  it('rejects a page with no derivable page number', () => {
+    expect(() => parseApp({ 'missing.apx': 'page example (\n  name: Example\n)' })).toThrow(/no derivable page number/);
+    expect(() => parseApp({ 'invalid.apx': 'page example (\n  page: nope\n  name: Example\n)' })).toThrow(/no derivable page number/);
+  });
+
+  it('rejects a page whose component-id contradicts its interior page: property', () => {
+    expect(() => parseApp({ 'contradiction.apx': 'page 1 (\n  page: 2\n  name: Example\n)' }))
+      .toThrow(/component-id \(1\) contradicts its interior 'page:' property \(2\)/);
+  });
+
+  it('derives the page number from the component-id alone, matching real Oracle-generated exports', () => {
+    // Real Oracle SQLcl/APEX exports never include an interior `page: N`
+    // property -- confirmed against oracle/apex's own 26.1 sample-reporting
+    // app (pages/p00001-interactive-report.apx opens `page 1 (` directly
+    // followed by `name: ...`, no interior `page:` line). See
+    // docs/quirks/26.1.json `page-number-not-required-property`.
+    const result = parseApp({
+      'p00001-interactive-report.apx': `page 1 (
+    name: Interactive Report
+    alias: INTERACTIVE-REPORT
+    title: Interactive Report
+)`,
+    });
+    expect(result.ast.pages[0]).toMatchObject({ identifier: '1', id: 1, alias: 'INTERACTIVE-REPORT' });
   });
 
   it('decodes quoted scalars and keeps whitespace inside quoted array values', () => {


### PR DESCRIPTION
Fixes #21.

## Summary

Two independently-confirmed parser bugs, same root pattern: the EBNF marks a property "required" *within* a group/block, but the whole group is one of several *optional* siblings at the parent level — real Oracle-generated exports correctly omit it, and this project's parser hard-threw instead of treating the absence as legitimate.

1. **Page number.** `projectPages()` required an interior `page: N` property inside every `page N ( ... )` block. Real exports never set it — the page number is already the component-id on the opening line (`n.identifier`), captured by the tokenizer but previously ignored for this purpose. Now derived from the component-id first, falling back to the interior property (kept as a consistency cross-check — a disagreement between the two now throws a specific, loud error instead of being silently resolved one way).
2. **`runtime.friendlyUrls`.** The app-level `runtime { }` group is one of ~20 optional sibling blocks under `app` (`javaScript`, `css`, `authentication`, ...) and may be absent entirely. `ApexApplication.runtime.friendlyUrls` is now typed `boolean | null` (`null` = not declared, never coerced to a guessed boolean). The generator's existing `?? true` fallback already handled `null` correctly with no further changes needed.

## Verification

Both bugs were confirmed against real data before fixing, not assumed from the issue report alone:
- Fetched the exact file cited in #21 (`oracle/apex`'s 26.1 branch, `sample-reporting` app, `pages/p00001-interactive-report.apx`) directly from GitHub — confirmed it opens `page 1 (` with no interior `page:` property anywhere except unrelated branch/link redirect targets.
- Fetched the raw Oracle EBNF and confirmed `<app-runtime>` is one of many optional group alternatives under `<app>`, and the real `application.apx` has no `runtime { }` block at all.
- Downloaded the **complete** real 42-page `sample-reporting` export and ran it through the full pipeline end-to-end: previously failed to parse at all (first on the page-number error, then — after that fix alone — on the `friendlyUrls` error); now parses with **zero warnings**, and `apx-testgen` generates all 42 page objects + specs successfully.

Both EBNF-vs-reality discrepancies are recorded in `docs/grammar-assumptions.md` with full evidence, per this project's convention for cases where the official spec and real export data disagree.

## Test plan

- [x] `npm run build` — all four packages, zero errors
- [x] `npm test --workspaces` — 502 tests passing, zero regressions (5 skipped, expected without `APX_EXPORT_DIR`)
- [x] Updated/added parser tests for both fixes, including a regression test using the real Oracle export shape and a new test proving a component-id/interior-property contradiction fails loudly rather than guessing
- [x] End-to-end verification against the real, complete `sample-reporting` export (not committed — Oracle sample-app redistribution policy, see `docs/limitations.md`)