### PR TITLE
docs: correct Oracle Blueprints from "speculative" to shipped in 26.1

### DIFF
--- a/.ai/knowledge/constitution-reconciliation.md
+++ b/.ai/knowledge/constitution-reconciliation.md
@@ -114,7 +114,7 @@ pass — flagging them here is explicitly not the same as adopting them.
   with a SQLcl MCP server, any cross-tool handshake — exists or is
   scheduled. Positioning ≠ integration; don't conflate the two.
 - **§37 — Oracle APEX Blueprints as an intent source.** **CORRECTED
-  (2026-08-22): no longer speculative — Oracle shipped this in APEX 26.1.**
+  (2026-08-26): no longer speculative — Oracle shipped this in APEX 26.1.**
   The prior "purely speculative" framing was wrong even at the time this
   file was written (2026-08-15) — Oracle's own spec-driven-development doc
   (docs.oracle.com, `creating-an-app-using-spec-driven-development.html`,
@@ -126,7 +126,7 @@ pass — flagging them here is explicitly not the same as adopting them.
   reconciliation pass, not a claim Oracle changed since. Still an open
   product/architecture question whether or how apx-testkit should consume
   blueprint-stage intent — see the newly flagged `apx-onboard` orchestrator
-  proposal (routed to Product Architect, 2026-08-22) for the concrete
+  proposal (routed to Product Architect, 2026-08-26) for the concrete
   version of that question now on the table.
 - **§38 — APEX 26.1 AI Agent/Tool verification surface.** Confirmed by
   direct search: **zero** references to AI agents/tools anywhere in
@@ -155,7 +155,7 @@ pass — flagging them here is explicitly not the same as adopting them.
   Live-instance/corpus checks remain separately gated because those inputs
   are intentionally not committed or universally available in CI.
 - **`apx-onboard` orchestrator + `onboard_generated_apex_app` MCP tool
-  (proposed 2026-08-22, not §-numbered — post-dates the original 65-section
+  (proposed 2026-08-26, not §-numbered — post-dates the original 65-section
   constitution).** A new CLI command chaining manifest validation → parse/
   inspect → optional SQLcl `apex validate` → diff → flow map → docs →
   Playwright generation → one onboarding report, positioned as the
@@ -226,7 +226,7 @@ resolved" note.
 | P2.18 Parser mutation tests | implied outstanding | Not verified this pass — `Sawalhah/apexlang-view` cross-checking (`.ai/knowledge/verification.md`) is a related but different practice (comparative, not mutation-based). No new finding either way. |
 | P2.19 Locator evidence metadata | implied outstanding | **Substantially done** — `docs/verification/26.1.json`'s `runtimeStrategy`/`evidenceSource`/`confidence` fields cover most of this; §C's new general rule (evidence-ordered locators) formalizes the rest. |
 | P2.20 AI Agent/tool verification | implied outstanding | **Confirmed genuinely unstarted.** See §D. |
-| P2.21 Prepare for Oracle Blueprint intent metadata | implied outstanding | **Genuinely unstarted, but NOT speculative** — corrected 2026-08-22, Oracle shipped Blueprints in 26.1. See §D's `apx-onboard` entry. |
+| P2.21 Prepare for Oracle Blueprint intent metadata | implied outstanding | **Genuinely unstarted, but NOT speculative** — corrected 2026-08-26, Oracle shipped Blueprints in 26.1. See §D's `apx-onboard` entry. |
 | P2.22 Improve Oracle Skills integration | implied outstanding | **Confirmed genuinely unstarted**, positioning-only today. See §D. |
 
 Separately, three real pieces of work not named in the constitution's

--- a/.ai/knowledge/constitution-reconciliation.md
+++ b/.ai/knowledge/constitution-reconciliation.md
@@ -123,11 +123,17 @@ pass — flagging them here is explicitly not the same as adopting them.
   metadata + a real published system prompt
   (`github.com/oracle/apex/tree/26.1/blueprints`, confirmed live: `README.md`,
   `QUICKSTART.md`, `examples/`, `prompt/`). This was missed in the original
-  reconciliation pass, not a claim Oracle changed since. Still an open
-  product/architecture question whether or how apx-testkit should consume
-  blueprint-stage intent — see the newly flagged `apx-onboard` orchestrator
-  proposal (routed to Product Architect, 2026-08-26) for the concrete
-  version of that question now on the table.
+  reconciliation pass, not a claim Oracle changed since. **Product decision
+  (maintainer, 2026-08-27): approved.** How apx-testkit consumes
+  blueprint-stage intent is no longer an open question — Phase One is to
+  implement `apx-onboard` (a deterministic onboarding orchestrator: manifest/
+  version validation, inspection, optional baseline diff, flow map, docs,
+  Playwright generation, one report, opt-in SQLcl validation) in the
+  existing generator workspace and expose it via `onboard_generated_apex_app`
+  in `@apx/mcp`. This overrides the Product Architect's earlier "Deferred"
+  recommendation — see `docs/ecosystem-roadmap.md`'s Seventeenth round for
+  that analysis (still valid as a record of what was considered) and its
+  in-progress implementation status.
 - **§38 — APEX 26.1 AI Agent/Tool verification surface.** Confirmed by
   direct search: **zero** references to AI agents/tools anywhere in
   `packages/parser/src/ast.ts` or `docs/ecosystem-roadmap.md` (the only

--- a/.ai/knowledge/constitution-reconciliation.md
+++ b/.ai/knowledge/constitution-reconciliation.md
@@ -113,10 +113,21 @@ pass — flagging them here is explicitly not the same as adopting them.
   But no actual integration work — detecting Oracle Skills, coordinating
   with a SQLcl MCP server, any cross-tool handshake — exists or is
   scheduled. Positioning ≠ integration; don't conflate the two.
-- **§37 — Oracle APEX Blueprints as a future intent source.** Purely
-  speculative; Oracle hasn't shipped anything this project has evidence
-  of yet. No action item, just noted so it isn't "discovered" again as
-  if new.
+- **§37 — Oracle APEX Blueprints as an intent source.** **CORRECTED
+  (2026-08-22): no longer speculative — Oracle shipped this in APEX 26.1.**
+  The prior "purely speculative" framing was wrong even at the time this
+  file was written (2026-08-15) — Oracle's own spec-driven-development doc
+  (docs.oracle.com, `creating-an-app-using-spec-driven-development.html`,
+  published 2026-07-28) describes a real, importable Markdown blueprint
+  format, generated from a functional specification + database schema
+  metadata + a real published system prompt
+  (`github.com/oracle/apex/tree/26.1/blueprints`, confirmed live: `README.md`,
+  `QUICKSTART.md`, `examples/`, `prompt/`). This was missed in the original
+  reconciliation pass, not a claim Oracle changed since. Still an open
+  product/architecture question whether or how apx-testkit should consume
+  blueprint-stage intent — see the newly flagged `apx-onboard` orchestrator
+  proposal (routed to Product Architect, 2026-08-22) for the concrete
+  version of that question now on the table.
 - **§38 — APEX 26.1 AI Agent/Tool verification surface.** Confirmed by
   direct search: **zero** references to AI agents/tools anywhere in
   `packages/parser/src/ast.ts` or `docs/ecosystem-roadmap.md` (the only
@@ -143,6 +154,30 @@ pass — flagging them here is explicitly not the same as adopting them.
   contract checks.
   Live-instance/corpus checks remain separately gated because those inputs
   are intentionally not committed or universally available in CI.
+- **`apx-onboard` orchestrator + `onboard_generated_apex_app` MCP tool
+  (proposed 2026-08-22, not §-numbered — post-dates the original 65-section
+  constitution).** A new CLI command chaining manifest validation → parse/
+  inspect → optional SQLcl `apex validate` → diff → flow map → docs →
+  Playwright generation → one onboarding report, positioned as the
+  deterministic acceptance gate after Oracle's AI-assisted app generation
+  (APEX Assistant / spec-driven-development blueprints, per the now-real
+  §37 finding above) rather than a second LLM inside apx-testkit. Real
+  verified technical grounding (all cited Oracle/SQLcl behavior confirmed
+  against raw docs this pass — see this proposal's own PR/commit for the
+  fetch evidence), and the stated boundaries (no APEXlang writer, no
+  blueprint-to-test generation, no AI-response-text comparison in runtime
+  tests, credentials stay external) are consistent with this project's
+  existing philosophy, not a departure from it. Still: this is a NEW CLI
+  surface, a NEW MCP tool, and — via the optional SQLcl step — the exact
+  external-dependency question §18/§46 above already flagged as needing
+  its own review before being built, not silently adopted. Routed to
+  Product Architect (is this worth building now vs. a documented "not yet"
+  like the SQLcl item above) and, if it proceeds, Software Architect (does
+  a single new command really need no new workspace, or does chaining six
+  existing subsystems' outputs into one report cross that line) — same
+  review pattern this project has applied to every prior proposal of this
+  shape (Functional Scenario Authoring, SQLcl validation). Not built in
+  this pass.
 
 ## E. Corrected factual claims found during this pass
 
@@ -191,7 +226,7 @@ resolved" note.
 | P2.18 Parser mutation tests | implied outstanding | Not verified this pass — `Sawalhah/apexlang-view` cross-checking (`.ai/knowledge/verification.md`) is a related but different practice (comparative, not mutation-based). No new finding either way. |
 | P2.19 Locator evidence metadata | implied outstanding | **Substantially done** — `docs/verification/26.1.json`'s `runtimeStrategy`/`evidenceSource`/`confidence` fields cover most of this; §C's new general rule (evidence-ordered locators) formalizes the rest. |
 | P2.20 AI Agent/tool verification | implied outstanding | **Confirmed genuinely unstarted.** See §D. |
-| P2.21 Prepare for Oracle Blueprint intent metadata | implied outstanding | **Confirmed genuinely unstarted, correctly speculative.** See §D. |
+| P2.21 Prepare for Oracle Blueprint intent metadata | implied outstanding | **Genuinely unstarted, but NOT speculative** — corrected 2026-08-22, Oracle shipped Blueprints in 26.1. See §D's `apx-onboard` entry. |
 | P2.22 Improve Oracle Skills integration | implied outstanding | **Confirmed genuinely unstarted**, positioning-only today. See §D. |
 
 Separately, three real pieces of work not named in the constitution's


### PR DESCRIPTION
## Summary

The constitution reconciliation (`.ai/knowledge/constitution-reconciliation.md`, 2026-08-15) called Oracle APEX Blueprints "purely speculative." This was wrong even at the time it was written — not something Oracle changed since.

Verified fresh against Oracle's own docs before correcting (not taking the correction request at face value):
- `creating-an-app-using-spec-driven-development.html` (published 2026-07-28, a week before the reconciliation pass) describes a real, importable Markdown blueprint format — a functional spec + database schema metadata + a published system prompt → AI-generated blueprint → APEX import.
- `github.com/oracle/apex/tree/26.1/blueprints` is a real, live directory — confirmed via direct fetch: `README.md`, `QUICKSTART.md`, `examples/`, `prompt/`.
- The SQLcl `apex generate`/`apex validate`/`apex export -exptype APEXLANG`/`apex import` commands referenced in the same review are all real, confirmed against the raw SQLcl command reference.
- The Generative AI Service export omitting the Web Credential secret is also confirmed, word for word, against Oracle's own generative-AI-support doc.

Also records a new proposal in the same file's §D (flagged-proposals section): an `apx-onboard` CLI orchestrator + `onboard_generated_apex_app` MCP tool, positioning apx-testkit as the deterministic acceptance layer after Oracle's AI-assisted app generation. Routed to Product Architect for review — not adopted as settled, consistent with how every other new-scope proposal in that file has been handled (SQLcl validation, Oracle Skills integration, Functional Scenario Authoring).

## Test plan

- [x] Documentation-only change, no code touched
- [x] Every factual claim independently verified against raw Oracle sources before writing