### PR TITLE
product-architect: defer apx-onboard orchestrator + MCP tool (retargeted to main)

### DIFF
--- a/.ai/knowledge/constitution-reconciliation.md
+++ b/.ai/knowledge/constitution-reconciliation.md
@@ -168,6 +168,17 @@ pass — flagging them here is explicitly not the same as adopting them.
   (proposed 2026-08-26, not §-numbered — post-dates the original 65-section
   constitution). Product Architect verdict landed 2026-08-26 — see
   `docs/ecosystem-roadmap.md`'s Seventeenth round for the full review.**
+  **SUPERSEDED (maintainer override, 2026-08-27): Phase One APPROVED —
+  the "Deferred" verdict and the "SQLcl scoped out" recommendation below
+  are both historical record, not current status.** The maintainer
+  directed implementation directly, including keeping SQLcl validation as
+  an **opt-in** step (not scoped out, as this entry originally
+  recommended). Implementation is in progress/under review as PR #27 —
+  see the Seventeenth round's override note for the authoritative current
+  status. Everything below this line is preserved as the record of what
+  was considered, not what's currently true.
+
+  **Original entry (superseded, preserved for the record):**
   **Status: Deferred, not Rejected** — same disposition as Functional
   Scenario Authoring (Sixteenth round), and for a related reason: no forcing
   consumer, no second real user (M4 still open), and — more specifically —

--- a/.ai/knowledge/constitution-reconciliation.md
+++ b/.ai/knowledge/constitution-reconciliation.md
@@ -134,15 +134,19 @@ pass — flagging them here is explicitly not the same as adopting them.
   recommendation — see `docs/ecosystem-roadmap.md`'s Seventeenth round for
   that analysis (still valid as a record of what was considered) and its
   in-progress implementation status.
-- **§38 — APEX 26.1 AI Agent/Tool verification surface.** Confirmed by
-  direct search: **zero** references to AI agents/tools anywhere in
-  `packages/parser/src/ast.ts` or `docs/ecosystem-roadmap.md` (the only
-  hits for "AI agent" in the whole repo are about *this project's own*
-  agents driving a browser, unrelated). This is a genuinely unstarted
-  capability, not a partially-built one. Needs Oracle APEX Architect
-  verification (does Oracle even expose enough at the APEXlang/export
-  level to model this statically?) before Compiler/Parser Engineer work
-  starts, per the standard pipeline in `.ai/AGENT.md`.
+- **§38 — APEX 26.1 AI Agent/Tool verification surface.** At the time this
+  pass was written: zero references to AI agents/tools anywhere in
+  `packages/parser/src/ast.ts` or `docs/ecosystem-roadmap.md`. **UPDATED
+  (2026-08-26): `docs/ecosystem-roadmap.md` now DOES discuss AI
+  agents/Blueprints extensively — the Seventeenth round's `apx-onboard`
+  review.** That's proposal-only documentation (a Product Architect
+  verdict record), not implementation — the accurate claim is **zero
+  implementation, zero typed-AST support** for APEX 26.1's AI Agent/Tool
+  capability itself, not "zero references in the repo." This is still a
+  genuinely unstarted capability, not a partially-built one. Needs Oracle
+  APEX Architect verification (does Oracle even expose enough at the
+  APEXlang/export level to model this statically?) before Compiler/Parser
+  Engineer work starts, per the standard pipeline in `.ai/AGENT.md`.
 - **§44 — "Oracle Evidence Registry" as a directory tree
   (`oracle/{apis/,components/,runtime/,grammar/,versions/}`).** This
   project already built the equivalent capability, in a different and
@@ -162,28 +166,70 @@ pass — flagging them here is explicitly not the same as adopting them.
   are intentionally not committed or universally available in CI.
 - **`apx-onboard` orchestrator + `onboard_generated_apex_app` MCP tool
   (proposed 2026-08-26, not §-numbered — post-dates the original 65-section
-  constitution).** A new CLI command chaining manifest validation → parse/
-  inspect → optional SQLcl `apex validate` → diff → flow map → docs →
-  Playwright generation → one onboarding report, positioned as the
-  deterministic acceptance gate after Oracle's AI-assisted app generation
-  (APEX Assistant / spec-driven-development blueprints, per the now-real
-  §37 finding above) rather than a second LLM inside apx-testkit. Real
-  verified technical grounding (all cited Oracle/SQLcl behavior confirmed
-  against raw docs this pass — see this proposal's own PR/commit for the
-  fetch evidence), and the stated boundaries (no APEXlang writer, no
-  blueprint-to-test generation, no AI-response-text comparison in runtime
-  tests, credentials stay external) are consistent with this project's
-  existing philosophy, not a departure from it. Still: this is a NEW CLI
-  surface, a NEW MCP tool, and — via the optional SQLcl step — the exact
-  external-dependency question §18/§46 above already flagged as needing
-  its own review before being built, not silently adopted. Routed to
-  Product Architect (is this worth building now vs. a documented "not yet"
-  like the SQLcl item above) and, if it proceeds, Software Architect (does
-  a single new command really need no new workspace, or does chaining six
-  existing subsystems' outputs into one report cross that line) — same
-  review pattern this project has applied to every prior proposal of this
-  shape (Functional Scenario Authoring, SQLcl validation). Not built in
-  this pass.
+  constitution). Product Architect verdict landed 2026-08-26 — see
+  `docs/ecosystem-roadmap.md`'s Seventeenth round for the full review.**
+  **Status: Deferred, not Rejected** — same disposition as Functional
+  Scenario Authoring (Sixteenth round), and for a related reason: no forcing
+  consumer, no second real user (M4 still open), and — more specifically —
+  nobody, including the maintainer, has yet run apx-testkit's existing six
+  MCP tools/CLIs by hand against a real Oracle-AI-generated APEXlang export
+  and reported genuine friction. The proposal's technical grounding is real
+  (Oracle's spec-driven-development blueprint workflow, SQLcl's `apex
+  generate`/`validate`/`import`/`export` surface, and the Generative-AI-
+  Service Web-Credential-omission claim all independently confirmed against
+  raw Oracle sources before this review), and its stated boundaries (no
+  APEXlang writer, no blueprint-to-test generation, no AI-response-text
+  comparison in runtime tests, credentials stay external) are consistent
+  with this project's philosophy and need no correction. What's missing is
+  evidence for the *specific* orchestration and report shape, not evidence
+  the underlying idea is sound. Steps 1, 2, 4, 5, 6, and 7 genuinely are
+  thin composition over already-verified, already-shipped output — the
+  `apx-report` precedent (Ninth round), not new capability. **CORRECTED
+  (review feedback, 2026-08-26): step 8's report is NOT pure composition —
+  the initial review overstated this.** `GenerateResult`
+  (`packages/generator/src/lib.ts`) exposes only `{ generated, skippedAuth,
+  outDir, warnings, unmodeled, files }`; the diagnostics an onboarding
+  report needs most (`navigationUnsafeSkipReason()`'s output, modal-page
+  skip notes, `skippedRegions`) exist today only as strings rendered into
+  generated `.spec.ts` comments, not as structured data on any exported
+  interface. Composing them into a report requires refactoring the
+  generator's public API — a real, separate implementation item needing
+  its own design and tests, not something `apx-onboard` gets for free by
+  calling existing functions. Parsing generated TypeScript comments back
+  out to recover this data should be rejected outright as an approach.
+  **The optional SQLcl `apex validate` step (step 3) stays scoped OUT of
+  any future v1 regardless of the rest of this proposal's fate** — it
+  remains the separate, already-flagged §18/§46 external-dependency
+  question, needing its own independent evidence and review, not something
+  to bundle in because it appeared in the same pipeline diagram. The new
+  MCP tool specifically does not pull its weight yet: any MCP-capable
+  agent can already dispatch the same six existing tools in sequence
+  itself — though "the same six" undersold a real distinction: the six
+  MCP tools (`inspect_apex_export`, `generate_apex_tests`,
+  `generate_flow_map`, `diff_apex_exports`, `analyze_coverage`,
+  `generate_apex_docs`) and the six CLI binaries (`apx-testgen`,
+  `apx-coverage`, `apx-diff`, `apx-docs`, `apx-flow`, `apx-report`) are NOT
+  the same six entry points — `apx-report` has no MCP-tool counterpart at
+  all. **Revisit trigger — CORRECTED (review feedback, 2026-08-26): the
+  original trigger wasn't actually executable as stated.** `diff_apex_exports`
+  requires BOTH an old and a new export directory (no single-export mode);
+  `analyze_coverage` requires a touch log that only exists after a
+  Playwright run with `APX_COVERAGE_LOG` set — neither is available from
+  "one real AI-generated app" alone. The real walkthrough needs two
+  branches: **no-baseline** (first-ever generation: `inspect` →
+  `generate_apex_tests` → `generate_flow_map` → `generate_apex_docs` — no
+  diff, no coverage yet) and **baseline** (a second AI-generated iteration
+  of the same app: adds `diff_apex_exports` against the first export, then
+  after running the generated Playwright suite with coverage logging
+  enabled, `analyze_coverage` against the resulting touch log). Either
+  branch, run once by hand, either surfaces genuine friction (evidence to
+  build `apx-onboard`, still without SQLcl) or composes cleanly (evidence
+  against the new MCP tool specifically) — the trigger's *purpose* survives
+  the correction unchanged, only its literal executability needed fixing.
+  **Does not proceed to a Software Architect pass at this time** — the
+  "does this need a new workspace" question is deferred along with the
+  rest of the proposal, to be taken up together once real evidence exists,
+  not before.
 
 ## E. Corrected factual claims found during this pass
 

--- a/docs/ecosystem-roadmap.md
+++ b/docs/ecosystem-roadmap.md
@@ -3715,7 +3715,24 @@ raw AST/Flow Map data itself.
 
 ## Seventeenth round (2026-08-26): `apx-onboard` orchestrator + `onboard_generated_apex_app` MCP tool — Product Architect verdict
 
-**Status: Deferred, not Rejected.** Same disposition shape as the
+**OVERRIDE (maintainer, 2026-08-27): Phase One APPROVED — implement now.**
+The Product Architect's "Deferred" verdict below was advisory, and the
+maintainer has since made the actual call: build `apx-onboard` in the
+existing generator workspace and expose it via
+`onboard_generated_apex_app`, with SQLcl validation kept as an **opt-in**
+step (not scoped out entirely, as this round originally recommended in
+Q2 below — resolve/require the SQLcl executable only when the option is
+explicitly requested, capture the result in the report, fail clearly if
+requested but unavailable). The analysis below is preserved as the record
+of what was considered — most of it (the MCP-vs-CLI distinction, the real
+`GenerateResult` API gap, the corrected baseline/no-baseline sequencing)
+remains directly load-bearing for the actual implementation; only the
+final timing verdict (Q5) and the SQLcl-out-of-scope recommendation (Q2)
+are superseded by this override, not the technical findings. See
+`.ai/knowledge/constitution-reconciliation.md`'s §37 entry for the
+corresponding record.
+
+**Original Status: Deferred, not Rejected** (superseded above). Same disposition shape as the
 Sixteenth round's Functional Scenario Authoring RFC, for a related but
 distinct reason. The premise this proposal rests on was independently
 fact-checked before reaching this review and holds up completely (Oracle's
@@ -3748,15 +3765,24 @@ below).
 
 ### 2. Should the optional SQLcl `apex validate` step be scoped out of v1?
 
-Yes, unambiguously, and this was never really in question. `.ai/knowledge/
-constitution-reconciliation.md` §D (§18/§46) and §62's P1.13 already flag
-SQLcl integration as "not started — correctly flagged as needing its own
-proposal" — a new external dependency (SQLcl availability in CI/dev
-environments), not something that should ride into apx-onboard's v1 scope
-as an "optional" step just because the rest of the orchestrator is
-low-risk. If apx-onboard is ever built, the SQLcl step stays a separate,
-later, independently-evidenced proposal — not bundled in because it was
-convenient to describe in the same pipeline diagram.
+**SUPERSEDED (maintainer override, 2026-08-27): No — keep it, as an
+explicit opt-in.** The recommendation below (scope it out entirely) is
+not what got built. The approved contract keeps SQLcl validation as part
+of `apx-onboard`, gated behind an explicit option: resolve/require the
+SQLcl executable only when that option is set, capture the validation
+result in the report, and fail with a clear, actionable error if the
+option is enabled but SQLcl isn't available — never silently skip a
+requested validation. This preserves portability (SQLcl is not a hard
+dependency for the default path) without dropping the capability the
+maintainer wants available.
+
+Original recommendation (not adopted, preserved for the record): scope it
+out entirely. `.ai/knowledge/constitution-reconciliation.md` §D (§18/§46)
+and §62's P1.13 already flag SQLcl integration as "not started —
+correctly flagged as needing its own proposal" — a new external
+dependency (SQLcl availability in CI/dev environments), not something
+that should ride into apx-onboard's v1 scope as an "optional" step just
+because the rest of the orchestrator is low-risk.
 
 ### 3. Is `apx-onboard` genuinely thin composition, or does it need new judgment?
 
@@ -3812,37 +3838,34 @@ this correction.
 
 ### 4. Does a new MCP tool pull its weight?
 
-Not yet. A seventh MCP tool is premature surface area for a workflow that
-has never been exercised even once, manually. Any MCP-capable agent
-today can already dispatch the same six existing tools in sequence
-itself — composing multiple tool calls is exactly what agentic tool use
-already supports, and this project's own MCP server doc comment frames
-the agent's job as dispatching generation, not needing a bespoke
-meta-tool per workflow. A single new orchestration entry point earns its
-keep once the underlying sequence has been run for real and specifically
-shown to be tedious or error-prone to compose by hand or via existing
-tools — not before.
+**SUPERSEDED (maintainer override, 2026-08-27): yes, build it.**
+`onboard_generated_apex_app` is part of the approved public surface, not
+a future possibility — implement one shared deterministic onboarding
+function in `@apx/testgen`, have the `apx-onboard` CLI call it, and
+register the MCP tool as a thin wrapper around that same function (the
+`apx-report`/`apx-diff` precedent for keeping CLI and MCP layers backed
+by one shared implementation, not two).
+
+Original recommendation (not adopted, preserved for the record): not yet
+— a seventh MCP tool is premature surface area for a workflow that has
+never been exercised even once, manually; any MCP-capable agent can
+already dispatch the same six existing tools in sequence itself.
 
 ### 5. Timing verdict
 
-**Deferred, not Rejected**, same framing this project used for the
-Sixteenth round's Functional Scenario Authoring RFC, and for the same
-reason that framing is accurate here: nothing about this proposal was
-found unsound. The maintainer's own stated boundaries (no APEXlang
-writer, no blueprint-to-test generation, no AI-response-text comparison
-in runtime tests, credentials stay external) are consistent with this
-project's existing philosophy and require no correction. What's missing
-is evidence the specific orchestration and report shape are what's
-actually needed, and that evidence is cheap to produce.
+**SUPERSEDED (maintainer override, 2026-08-27): build now.** See the
+override note at the top of this round.
 
-**This does not proceed to a Software Architect pass right now.** Unlike
-the Sixteenth round (where the RFC's architecture was reviewed in
-parallel because the design itself needed correcting before any future
-build), there is no open architecture question here worth a dedicated
-pass yet — "does chaining six existing subsystems into one report need a
-new workspace" doesn't need answering until there's an actual proposal on
-the table with real evidence behind it. Revisit that question together
-with the revisit trigger below, not before.
+Original verdict (not adopted, preserved for the record): **Deferred, not
+Rejected**, same framing this project used for the Sixteenth round's
+Functional Scenario Authoring RFC. The maintainer's own stated boundaries
+(no APEXlang writer, no blueprint-to-test generation, no AI-response-text
+comparison in runtime tests, credentials stay external) are consistent
+with this project's existing philosophy and require no correction. This
+recommended not proceeding to a Software Architect pass and waiting for
+one manual walkthrough as evidence — superseded by the maintainer
+deciding directly, which is the actual authority this analysis was always
+advisory to.
 
 ### What would change this verdict
 
@@ -3885,7 +3908,10 @@ evidence *against* building a seventh MCP tool specifically, not a wasted
 exercise either way. Either outcome is useful; neither requires new code,
 an external customer, or the SQLcl dependency this review scoped out.
 
-Until that walkthrough happens, `apx-onboard` and `onboard_generated_apex_app`
-stay unbuilt and unscheduled, same as Functional Scenario Authoring — a
-well-reasoned idea whose time has not yet been earned by evidence, logged
-here so it isn't rediscovered as a gap later.
+**SUPERSEDED (maintainer override, 2026-08-27):** the walkthrough-first
+gate above was this round's own recommended path to build; the maintainer
+instead approved Phase One directly. The corrected sequencing above
+(no-baseline vs. baseline branches, real tool names) remains the accurate
+technical description of how `apx-onboard` needs to behave — it just
+stopped being a revisit *trigger* and became the implementation's actual
+functional spec.

--- a/docs/ecosystem-roadmap.md
+++ b/docs/ecosystem-roadmap.md
@@ -3712,3 +3712,147 @@ remembering: it would make any eventual AI authoring layer's job both
 easier and more tightly constrained, since the layer would be
 interpreting pre-extracted deterministic candidates rather than reading
 raw AST/Flow Map data itself.
+
+## Seventeenth round (2026-08-26): `apx-onboard` orchestrator + `onboard_generated_apex_app` MCP tool — Product Architect verdict
+
+**Status: Deferred, not Rejected.** Same disposition shape as the
+Sixteenth round's Functional Scenario Authoring RFC, for a related but
+distinct reason. The premise this proposal rests on was independently
+fact-checked before reaching this review and holds up completely (Oracle's
+spec-driven-development blueprint workflow is real and shipped in 26.1;
+SQLcl's `apex generate`/`apex validate -input`/`apex export -exptype
+APEXLANG`/`apex import -input` are all real; the Generative-AI-Service
+Web-Credential-omission claim is accurate) — nothing here is a factual
+correction. This is a scope/timing verdict, not a fact check.
+
+### 1. Real, validated user pain, or architecturally interesting ahead of need?
+
+Ahead of need, but for a narrower and cheaper-to-close reason than most
+prior rejections in this file. This project still has not hit its own M4
+milestone — no second real user (confirmed unchanged as of the Sixteenth
+round, 2026-08-14, and rechecked here: no evidence anything has changed).
+But the more specific gap is this: **nobody, including the maintainer, has
+yet run apx-testkit's existing tools by hand against a real AI-generated
+APEXlang export and reported what's actually tedious or missing.** Oracle's
+spec-driven blueprint doc was published 2026-07-28 — under a month before
+this proposal. The proposed onboarding report's contents (parser warnings;
+unmodeled AI-generated components; changed pages; unsafe or skipped
+assertions; generated files; live-verification requirements) are designed
+from reading Oracle's documentation and this project's own existing
+outputs, not from having actually produced one AI-generated app, exported
+it, and hit friction running the six existing tools against it in
+sequence. That is a materially different, and much cheaper, evidence gap
+to close than "wait for a second user" — it doesn't require an external
+customer, just one real walkthrough (see "What would change this verdict"
+below).
+
+### 2. Should the optional SQLcl `apex validate` step be scoped out of v1?
+
+Yes, unambiguously, and this was never really in question. `.ai/knowledge/
+constitution-reconciliation.md` §D (§18/§46) and §62's P1.13 already flag
+SQLcl integration as "not started — correctly flagged as needing its own
+proposal" — a new external dependency (SQLcl availability in CI/dev
+environments), not something that should ride into apx-onboard's v1 scope
+as an "optional" step just because the rest of the orchestrator is
+low-risk. If apx-onboard is ever built, the SQLcl step stays a separate,
+later, independently-evidenced proposal — not bundled in because it was
+convenient to describe in the same pipeline diagram.
+
+### 3. Is `apx-onboard` genuinely thin composition, or does it need new judgment?
+
+Checked directly against the real code, not taken on the maintainer's
+"most of this already exists" framing: **mostly genuine composition,
+closely matching the `apx-report` precedent** (Ninth round: pure bundling
+of already-computed coverage/diff/warning data, no new analysis, approved
+and shipped for exactly that reason). Confirmed in this repo:
+
+- Six MCP tools (`inspect_apex_export`, `generate_apex_tests`,
+  `generate_flow_map`, `diff_apex_exports`, `analyze_coverage`,
+  `generate_apex_docs`) already exist in `packages/mcp/src/server.ts`,
+  each a thin `registerTool` wrapper over an `@apx/testgen` function —
+  confirmed no LLM import anywhere in that file (the file's own doc
+  comment states this as a design invariant).
+- Six CLI binaries already exist in `packages/generator/package.json`'s
+  `bin` block: `apx-testgen`, `apx-coverage`, `apx-diff`, `apx-docs`,
+  `apx-flow`, `apx-report`.
+- The onboarding report's proposed sections are, with one exception,
+  already-computed data, not new heuristics: parser warnings is
+  `ParseResult.warnings` verbatim; "unmodeled AI-generated components" is
+  the generator's existing `unmodeled` list (CLAUDE.md debt #6); changed
+  pages is `apx-diff`'s existing `DiffReport`; generated files is already
+  derived from the shared `pageObjectFileName()`/`specFileName()` helpers
+  `apx-diff` itself reuses (Ninth round); "unsafe or skipped assertions"
+  has real, already-computed backing today
+  (`navigationUnsafeSkipReason()`, the `modalDialog` unroutable-page note,
+  `skippedRegions` — all in `packages/generator/src/lib.ts`, currently
+  surfaced only as comments inside generated spec files, not yet as
+  structured report data).
+
+The one exception is the SQLcl step (scoped out per Q2). Everything else
+is assembling outputs this project has already independently verified —
+genuinely low implementation risk, unlike Functional Scenario Authoring's
+new artifact type, new evidence-tiering scheme, and first-ever LLM
+dependency. But "low risk to build" is not the same as "known to be
+useful": nobody has assembled these specific fields into a report and
+had a real user read it. The design is plausible, not proven.
+
+### 4. Does a new MCP tool pull its weight?
+
+Not yet. A seventh MCP tool is premature surface area for a workflow that
+has never been exercised even once, manually. Any MCP-capable agent
+today can already dispatch the same six existing tools in sequence
+itself — composing multiple tool calls is exactly what agentic tool use
+already supports, and this project's own MCP server doc comment frames
+the agent's job as dispatching generation, not needing a bespoke
+meta-tool per workflow. A single new orchestration entry point earns its
+keep once the underlying sequence has been run for real and specifically
+shown to be tedious or error-prone to compose by hand or via existing
+tools — not before.
+
+### 5. Timing verdict
+
+**Deferred, not Rejected**, same framing this project used for the
+Sixteenth round's Functional Scenario Authoring RFC, and for the same
+reason that framing is accurate here: nothing about this proposal was
+found unsound. The maintainer's own stated boundaries (no APEXlang
+writer, no blueprint-to-test generation, no AI-response-text comparison
+in runtime tests, credentials stay external) are consistent with this
+project's existing philosophy and require no correction. What's missing
+is evidence the specific orchestration and report shape are what's
+actually needed, and that evidence is cheap to produce.
+
+**This does not proceed to a Software Architect pass right now.** Unlike
+the Sixteenth round (where the RFC's architecture was reviewed in
+parallel because the design itself needed correcting before any future
+build), there is no open architecture question here worth a dedicated
+pass yet — "does chaining six existing subsystems into one report need a
+new workspace" doesn't need answering until there's an actual proposal on
+the table with real evidence behind it. Revisit that question together
+with the revisit trigger below, not before.
+
+### What would change this verdict
+
+A concrete, cheap, and specific trigger, narrower than "wait for a second
+user": **run the existing pipeline by hand, once, for real.** Use Oracle
+APEX Assistant or the 26.1 spec-driven blueprint workflow to generate one
+real application, export it as APEXlang, and run apx-testkit's existing
+six tools/CLIs against it in the sequence this proposal describes
+(inspect → diff → flow map → docs → Playwright generation). If that
+walkthrough surfaces genuine friction — commands run in the wrong order,
+outputs that are awkward to cross-reference by hand, a report section
+that would have caught something a person missed — that's real evidence
+apx-onboard's specific shape is worth building, and exactly the kind of
+ground truth this project's whole evidence-over-assumption discipline
+already requires everywhere else (Chart and Calendar both waited for a
+live instance before runtime treatment; this is the same test applied to
+a workflow instead of a component). If the walkthrough instead shows the
+six existing tools already compose cleanly by hand or via an agent
+chaining six MCP calls, that's evidence *against* building a seventh tool,
+not a wasted exercise either way. Either outcome is useful; neither
+requires new code, an external customer, or the SQLcl dependency this
+review scoped out.
+
+Until that walkthrough happens, `apx-onboard` and `onboard_generated_apex_app`
+stay unbuilt and unscheduled, same as Functional Scenario Authoring — a
+well-reasoned idea whose time has not yet been earned by evidence, logged
+here so it isn't rediscovered as a gap later.

--- a/docs/ecosystem-roadmap.md
+++ b/docs/ecosystem-roadmap.md
@@ -3761,10 +3761,12 @@ convenient to describe in the same pipeline diagram.
 ### 3. Is `apx-onboard` genuinely thin composition, or does it need new judgment?
 
 Checked directly against the real code, not taken on the maintainer's
-"most of this already exists" framing: **mostly genuine composition,
-closely matching the `apx-report` precedent** (Ninth round: pure bundling
-of already-computed coverage/diff/warning data, no new analysis, approved
-and shipped for exactly that reason). Confirmed in this repo:
+"most of this already exists" framing. **CORRECTED (review feedback,
+2026-08-26): the original version of this section overstated how much of
+step 8 (the report) is pure composition.** Steps 1, 2, 4, 5, 6, and 7
+genuinely are, closely matching the `apx-report` precedent (Ninth round:
+pure bundling of already-computed coverage/diff/warning data, no new
+analysis) — confirmed in this repo:
 
 - Six MCP tools (`inspect_apex_export`, `generate_apex_tests`,
   `generate_flow_map`, `diff_apex_exports`, `analyze_coverage`,
@@ -3774,27 +3776,39 @@ and shipped for exactly that reason). Confirmed in this repo:
   comment states this as a design invariant).
 - Six CLI binaries already exist in `packages/generator/package.json`'s
   `bin` block: `apx-testgen`, `apx-coverage`, `apx-diff`, `apx-docs`,
-  `apx-flow`, `apx-report`.
-- The onboarding report's proposed sections are, with one exception,
-  already-computed data, not new heuristics: parser warnings is
-  `ParseResult.warnings` verbatim; "unmodeled AI-generated components" is
-  the generator's existing `unmodeled` list (CLAUDE.md debt #6); changed
-  pages is `apx-diff`'s existing `DiffReport`; generated files is already
-  derived from the shared `pageObjectFileName()`/`specFileName()` helpers
-  `apx-diff` itself reuses (Ninth round); "unsafe or skipped assertions"
-  has real, already-computed backing today
-  (`navigationUnsafeSkipReason()`, the `modalDialog` unroutable-page note,
-  `skippedRegions` — all in `packages/generator/src/lib.ts`, currently
-  surfaced only as comments inside generated spec files, not yet as
-  structured report data).
+  `apx-flow`, `apx-report`. **These are NOT the same six entry points as
+  the MCP tools above** — `apx-report` has no MCP-tool counterpart, and
+  `inspect_apex_export` has no standalone CLI binary of its own. An
+  orchestrator description that says "the same six tools" for both layers
+  is wrong and needs to name each set separately.
+- Report fields with genuinely already-computed, already-structured
+  backing: parser warnings (`ParseResult.warnings` verbatim), "unmodeled
+  AI-generated components" (the generator's existing `unmodeled` list,
+  CLAUDE.md debt #6), changed pages (`apx-diff`'s existing `DiffReport`),
+  and generated files (the shared `pageObjectFileName()`/`specFileName()`
+  helpers `apx-diff` itself reuses, Ninth round).
 
-The one exception is the SQLcl step (scoped out per Q2). Everything else
-is assembling outputs this project has already independently verified —
-genuinely low implementation risk, unlike Functional Scenario Authoring's
-new artifact type, new evidence-tiering scheme, and first-ever LLM
-dependency. But "low risk to build" is not the same as "known to be
-useful": nobody has assembled these specific fields into a report and
-had a real user read it. The design is plausible, not proven.
+**"Unsafe or skipped assertions" is NOT already-computed backing — this is
+real, additional implementation work, not composition.**
+`GenerateResult` (`packages/generator/src/lib.ts`) exposes only
+`{ generated, skippedAuth, outDir, warnings, unmodeled, files }`.
+`navigationUnsafeSkipReason()`'s output, the `modalDialog` unroutable-page
+note, and `skippedRegions` are real and computed today, but only as
+strings rendered directly into generated `.spec.ts` file comments during
+page-object generation — never returned on any exported interface. An
+onboarding report cannot access this data structurally without refactoring
+the generator's public API to surface it (a real API design task, with
+its own tests, not free from calling an existing function) — and parsing
+the generated TypeScript comments back out to recover it should be
+rejected outright as an approach.
+
+The SQLcl step (scoped out per Q2) and this report-diagnostics gap are
+BOTH real, separate implementation items on top of the genuine
+composition in steps 1/2/4/5/6/7 — "low risk to build" was too strong a
+characterization of the whole proposal. It remains true that nobody has
+assembled even the genuinely-composable fields into a report and had a
+real user read it, so the design is plausible, not proven, independent of
+this correction.
 
 ### 4. Does a new MCP tool pull its weight?
 
@@ -3833,24 +3847,43 @@ with the revisit trigger below, not before.
 ### What would change this verdict
 
 A concrete, cheap, and specific trigger, narrower than "wait for a second
-user": **run the existing pipeline by hand, once, for real.** Use Oracle
-APEX Assistant or the 26.1 spec-driven blueprint workflow to generate one
-real application, export it as APEXlang, and run apx-testkit's existing
-six tools/CLIs against it in the sequence this proposal describes
-(inspect → diff → flow map → docs → Playwright generation). If that
-walkthrough surfaces genuine friction — commands run in the wrong order,
-outputs that are awkward to cross-reference by hand, a report section
-that would have caught something a person missed — that's real evidence
-apx-onboard's specific shape is worth building, and exactly the kind of
-ground truth this project's whole evidence-over-assumption discipline
-already requires everywhere else (Chart and Calendar both waited for a
-live instance before runtime treatment; this is the same test applied to
-a workflow instead of a component). If the walkthrough instead shows the
-six existing tools already compose cleanly by hand or via an agent
-chaining six MCP calls, that's evidence *against* building a seventh tool,
-not a wasted exercise either way. Either outcome is useful; neither
-requires new code, an external customer, or the SQLcl dependency this
-review scoped out.
+user": **run the existing pipeline by hand, once, for real.**
+
+**CORRECTED (review feedback, 2026-08-26): the original version of this
+trigger was not actually executable as described** — it said "six tools"
+but listed five operations (inspect/diff/flow map/docs/generate), and
+implied a single AI-generated export was sufficient input for all of
+them. Neither holds: `diff_apex_exports` requires BOTH an old and a new
+export directory (no single-export mode — `packages/mcp/src/server.ts`
+rejects a missing `oldExportDir`/`newExportDir` outright), and
+`analyze_coverage` requires a touch log that is written only by
+`@apx/testkit`'s opt-in recorder during an actual Playwright run with
+`APX_COVERAGE_LOG` set — it cannot exist before tests have been generated
+AND executed. The real walkthrough needs two branches, run against Oracle
+APEX Assistant or the 26.1 spec-driven blueprint workflow:
+
+- **No-baseline (first-ever generation of an app):** `inspect_apex_export`
+  → `generate_apex_tests` → `generate_flow_map` → `generate_apex_docs`. No
+  diff (nothing to diff against yet), no coverage (no test run yet).
+- **Baseline (a second AI-generated iteration of the same app):** the
+  no-baseline sequence, plus `diff_apex_exports` against the first
+  export's directory, plus — after actually running the generated
+  Playwright suite with `APX_COVERAGE_LOG` set — `analyze_coverage`
+  against the resulting touch log.
+
+Either branch, run once by hand, surfaces the same two possible outcomes
+the original trigger intended: genuine friction (commands run in the
+wrong order, outputs awkward to cross-reference, a report section that
+would have caught something a person missed) is real evidence
+`apx-onboard`'s specific shape is worth building — the same kind of
+ground truth this project's evidence-over-assumption discipline already
+requires everywhere else (Chart and Calendar both waited for a live
+instance before runtime treatment; this is the same test applied to a
+workflow instead of a component). Composing cleanly already — whether by
+hand or via an agent chaining the relevant MCP tool calls itself — is
+evidence *against* building a seventh MCP tool specifically, not a wasted
+exercise either way. Either outcome is useful; neither requires new code,
+an external customer, or the SQLcl dependency this review scoped out.
 
 Until that walkthrough happens, `apx-onboard` and `onboard_generated_apex_app`
 stay unbuilt and unscheduled, same as Functional Scenario Authoring — a


### PR DESCRIPTION
Replaces #26, which GitHub auto-closed (and made permanently unreopenable/unretargetable) when its base branch (`docs/correct-blueprints-speculative-claim`, PR #25) was deleted on merge. Same branch (`product-architect/apx-onboard-review`), same commits, no content changes — just retargeted to `main` now that #25 is merged.

Original description (unchanged):

Product Architect review of the `apx-onboard` CLI orchestrator + `onboard_generated_apex_app` MCP tool proposal — initially verdict "Deferred, not Rejected," subsequently **superseded by the maintainer's explicit override approving Phase One** (see this branch's later commits and `docs/ecosystem-roadmap.md`'s Seventeenth round override note). Also includes two rounds of real review-comment corrections (technical accuracy fixes, then the maintainer's Phase-One-approved override recorded in place, preserving the original advisory analysis as clearly-marked historical record rather than deleting it).

The actual implementation shipped separately as #27 (now merged), per the plan recorded in this thread.

## Test plan

- [x] Documentation-only change (`docs/ecosystem-roadmap.md`, `.ai/knowledge/constitution-reconciliation.md`) — no code touched
- [x] Previously CI-green as #26; recheck below